### PR TITLE
Update the API to follow REST practices

### DIFF
--- a/src/caad_erp/api/routes/products.py
+++ b/src/caad_erp/api/routes/products.py
@@ -1,7 +1,6 @@
 """Product management endpoints for the CAAD ERP API.
 
-This module provides REST endpoints for creating and deactivating products,
-mirroring the CLI commands add-product and deactivate-product.
+This module provides REST endpoints for managing products.
 """
 
 import fastapi
@@ -16,8 +15,7 @@ router = fastapi.APIRouter(prefix="/products", tags=["Products"])
 @router.get("", response_model=schemas.ProductListResponse)
 def list_products(
     include_inactive: bool = False,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.ProductListResponse:
     """List products, optionally including inactive ones.
 
@@ -47,8 +45,7 @@ def list_products(
 @persistence.mutating_endpoint
 def create_product(
     request: schemas.ProductCreateRequest,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Create a new product.
 
@@ -82,36 +79,44 @@ def create_product(
     )
 
 
-@router.post("/{product_id}/deactivate", response_model=schemas.StandardResponse)
-@persistence.mutating_endpoint
-def deactivate_product(
+@router.get("/{product_id}", response_model=schemas.ProductResponse)
+def get_product(
     product_id: str,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
+) -> schemas.ProductResponse:
+    """Get a specific product by ID."""
+    products = bll.list_products(context, include_inactive=True)
+    product = list(filter(lambda row: row.product_id == product_id, products))[0]
+    return schemas.ProductResponse(
+        product_id=product.product_id,
+        product_name=product.product_name,
+        sell_price=product.sell_price,
+        is_active=product.is_active,
+    )
+
+
+@router.patch("/{product_id}", response_model=schemas.StandardResponse)
+@persistence.mutating_endpoint
+def update_product_details(
+    product_id: str,
+    request: schemas.ProductUpdateRequest,
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
-    """Deactivate an existing product.
+    """Update an existing product.
 
-    Args:
-        product_id: The ID of the product to deactivate.
-        context: Runtime context injected via dependency.
-
-    Returns:
-        StandardResponse containing the updated product data.
-
-    Raises:
-        HTTPException: 404 if product not found.
+    Can be used to modify the product's name, price, or toggle its active status.
     """
     product = bll.update_product(
         context,
         bll.ProductCommand(
             product_id=product_id,
-            product_name=None,
-            sell_price=None,
-            is_active=False,
+            product_name=request.product_name,
+            sell_price=request.sell_price,
+            is_active=request.is_active,
         ),
     )
     return schemas.StandardResponse(
-        detail="Product deactivated successfully",
+        detail="Product updated successfully",
         data=schemas.ProductResponse(
             product_id=product.product_id,
             product_name=product.product_name,

--- a/src/caad_erp/api/routes/salesmen.py
+++ b/src/caad_erp/api/routes/salesmen.py
@@ -1,7 +1,6 @@
 """Salesman management endpoints for the CAAD ERP API.
 
-This module provides REST endpoints for creating and deactivating salesmen,
-mirroring the CLI commands add-salesman and deactivate-salesman.
+This module provides REST endpoints for managing salesmen,
 """
 
 import fastapi
@@ -16,8 +15,7 @@ router = fastapi.APIRouter(prefix="/salesmen", tags=["Salesmen"])
 @router.get("", response_model=schemas.SalesmanListResponse)
 def list_salesmen(
     include_inactive: bool = False,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.SalesmanListResponse:
     """List salesmen, optionally including inactive ones.
 
@@ -46,8 +44,7 @@ def list_salesmen(
 @persistence.mutating_endpoint
 def create_salesman(
     request: schemas.SalesmanCreateRequest,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Create a new salesman.
 
@@ -79,35 +76,42 @@ def create_salesman(
     )
 
 
-@router.post("/{salesman_id}/deactivate", response_model=schemas.StandardResponse)
-@persistence.mutating_endpoint
-def deactivate_salesman(
+@router.get("/{salesman_id}", response_model=schemas.SalesmanResponse)
+def get_salesman(
     salesman_id: str,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
+) -> schemas.SalesmanResponse:
+    """Get a specific salesman by ID."""
+    salesmen = bll.list_salesmen(context, include_inactive=True)
+    salesman = list(filter(lambda row: row.salesman_id == salesman_id, salesmen))[0]
+    return schemas.SalesmanResponse(
+        salesman_id=salesman.salesman_id,
+        salesman_name=salesman.salesman_name,
+        is_active=salesman.is_active,
+    )
+
+
+@router.patch("/{salesman_id}", response_model=schemas.StandardResponse)
+@persistence.mutating_endpoint
+def update_salesman_details(
+    salesman_id: str,
+    request: schemas.SalesmanUpdateRequest,
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
-    """Deactivate an existing salesman.
+    """Update an existing salesman.
 
-    Args:
-        salesman_id: The ID of the salesman to deactivate.
-        context: Runtime context injected via dependency.
-
-    Returns:
-        StandardResponse containing the updated salesman data.
-
-    Raises:
-        HTTPException: 404 if salesman not found.
+    Can be used to modify the salesman's name or toggle their active status.
     """
     salesman = bll.update_salesman(
         context,
         bll.SalesmanCommand(
             salesman_id=salesman_id,
-            salesman_name=None,
-            is_active=False,
+            salesman_name=request.salesman_name,
+            is_active=request.is_active,
         ),
     )
     return schemas.StandardResponse(
-        detail="Salesman deactivated successfully",
+        detail="Salesman updated successfully",
         data=schemas.SalesmanResponse(
             salesman_id=salesman.salesman_id,
             salesman_name=salesman.salesman_name,

--- a/src/caad_erp/api/schemas.py
+++ b/src/caad_erp/api/schemas.py
@@ -34,6 +34,14 @@ class ProductCreateRequest(pydantic.BaseModel):
     is_active: bool = True
 
 
+class ProductUpdateRequest(pydantic.BaseModel):
+    """Request payload for partially updating an existing product."""
+
+    product_name: t.Optional[str] = pydantic.Field(None, min_length=1)
+    sell_price: t.Optional[int] = pydantic.Field(None, ge=0)
+    is_active: t.Optional[bool] = None
+
+
 class ProductResponse(pydantic.BaseModel):
     """Response representation of a product record."""
 
@@ -49,6 +57,13 @@ class SalesmanCreateRequest(pydantic.BaseModel):
     salesman_id: str = pydantic.Field(..., min_length=1)
     salesman_name: str = pydantic.Field(..., min_length=1)
     is_active: bool = True
+
+
+class SalesmanUpdateRequest(pydantic.BaseModel):
+    """Request payload for partially updating an existing salesman."""
+
+    salesman_name: t.Optional[str] = pydantic.Field(None, min_length=1)
+    is_active: t.Optional[bool] = None
 
 
 class SalesmanResponse(pydantic.BaseModel):
@@ -116,7 +131,7 @@ class PayDebtRequest(pydantic.BaseModel):
                 "Payment type 'OnCredit' is not allowed when settling a debt"
             )
         return value
-    
+
 
 class ProductListResponse(pydantic.BaseModel):
     """Response for listing products."""


### PR DESCRIPTION
Fixes #30 

---

Still needs to update the CLI and the documentation

---

This pull request refactors and extends the API endpoints for managing products and salesmen. It replaces the previous "deactivate" endpoints with more general update endpoints, adds endpoints to fetch individual records by ID, and introduces new request schemas to support partial updates. The changes also include minor code cleanups for consistency.

**API Endpoint Refactoring and Feature Additions:**

* The product and salesman "deactivate" endpoints (`POST /{id}/deactivate`) have been replaced with more general update endpoints (`PATCH /{id}`), allowing partial updates to name, price, and active status. [[1]](diffhunk://#diff-5e5f9984754620ad2d52f566d5eccdb0ec404fab2649f9eacf6bb5a2cba70b14L85-R119) [[2]](diffhunk://#diff-7017ee74120e5301b240edcfa1c4ec5e4c01ac688eabaa6e74a1df2b9688b90eL82-R114)
* New endpoints have been added to fetch individual products and salesmen by ID (`GET /{id}` for both resources). [[1]](diffhunk://#diff-5e5f9984754620ad2d52f566d5eccdb0ec404fab2649f9eacf6bb5a2cba70b14L85-R119) [[2]](diffhunk://#diff-7017ee74120e5301b240edcfa1c4ec5e4c01ac688eabaa6e74a1df2b9688b90eL82-R114)
* Introduced new request schemas: `ProductUpdateRequest` and `SalesmanUpdateRequest`, supporting partial updates for the respective resources. [[1]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6R37-R44) [[2]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6R62-R68)

**Code Cleanup:**

* Updated module docstrings in `products.py` and `salesmen.py` to reflect the expanded management capabilities. [[1]](diffhunk://#diff-5e5f9984754620ad2d52f566d5eccdb0ec404fab2649f9eacf6bb5a2cba70b14L3-R3) [[2]](diffhunk://#diff-7017ee74120e5301b240edcfa1c4ec5e4c01ac688eabaa6e74a1df2b9688b90eL3-R3)