### PR TITLE
Remove filtering from the server

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -185,8 +185,7 @@ instance. To avoid repeatedly walking the Excel sheets (an `openpyxl` iterator
 can be expensive for large ledgers), the context maintains an in-memory cache
 with these buckets:
 
-- `products`: memoized list of every product (`all`), an `active` subset, and an
-  id-index map (`by_id`).
+- `products`: memoized list of every product (`all`), id-index map (`by_id`).
 - `salesmen`: the same structure for salesmen.
 - `transactions`: immutable transaction rows plus an id-index.
 
@@ -272,7 +271,7 @@ rename it, which would fatally break all logic for tracking and paying debts.
 workflow 100% robust and safe from user error, at the minor cost of requiring a
 developer to add new payment types.
 
-## "Deleting" something
+### "Deleting" something
 
 Soft-delete is our method for "removing" an item (like a product or a salesman)
 without corrupting our database.
@@ -284,7 +283,7 @@ Instead of actually deleting the row from the Excel sheet, just flip the
 instantly vanish from the `stock` report and from the list of items you can
 `sale`. To the user, it's "deleted."
 
-### Why This is Absolutely Needed
+#### Why This is Absolutely Needed
 
 The main reason is to **protect our `TransactionLog`'s history**.
 
@@ -317,7 +316,7 @@ When we set `P1001`'s `IsActive` to `FALSE`:
 3. When you run a profit report for last month, the BLL can still look up
    `P1001`, find "Snickers," and correctly calculate your historical profit.
 
-### The only case we "Hard-Delete" (Archive Script)
+#### The only case we "Hard-Delete" (Archive Script)
 
 This is the "pruning" or "garbage collection". It happens only when a manager
 runs the period-end archive script.
@@ -331,6 +330,16 @@ if the inventory is 0. If this is true, then it will actually remove
 
 It does a similar thing for sellers looking at the debt and any other necessary
 info
+
+### Why don't list-products/list-salesmen filter by active status server-side?
+
+`Products` and `Salesmen` are expected to stay small (dozens to low hundreds of
+rows), so pushing "include inactive" filtering to the server added complexity
+(extra cache buckets, query params, CLI flags) without a real performance
+benefit. `list_products`/`list_salesmen` (BLL), the CLI
+`list-products`/`list-salesmen` commands, and the `GET /products` /
+`GET /salesmen` endpoints always return the full dataset, so clients can filter
+or sort however they like.
 
 ## Future Work
 

--- a/src/caad_erp/api/routes/products.py
+++ b/src/caad_erp/api/routes/products.py
@@ -15,21 +15,19 @@ router = fastapi.APIRouter(prefix="/products", tags=["Products"])
 
 @router.get("", response_model=schemas.ProductListResponse)
 def list_products(
-    include_inactive: bool = False,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.ProductListResponse:
-    """List products, optionally including inactive ones.
+    """List all products.
+
+    Filtering by active status is a client-side concern.
 
     Args:
-        include_inactive: When True, inactive products are included.
-            Mirrors the CLI ``--all`` flag. Defaults to False.
         context: Runtime context injected via dependency.
 
     Returns:
-        ProductListResponse containing the matching product records.
+        ProductListResponse containing every product record.
     """
-    products = bll.list_products(context, include_inactive=include_inactive)
+    products = bll.list_products(context)
     return schemas.ProductListResponse(
         items=[
             schemas.ProductResponse(
@@ -47,8 +45,7 @@ def list_products(
 @persistence.mutating_endpoint
 def create_product(
     request: schemas.ProductCreateRequest,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Create a new product.
 
@@ -86,8 +83,7 @@ def create_product(
 @persistence.mutating_endpoint
 def deactivate_product(
     product_id: str,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Deactivate an existing product.
 

--- a/src/caad_erp/api/routes/salesmen.py
+++ b/src/caad_erp/api/routes/salesmen.py
@@ -15,21 +15,19 @@ router = fastapi.APIRouter(prefix="/salesmen", tags=["Salesmen"])
 
 @router.get("", response_model=schemas.SalesmanListResponse)
 def list_salesmen(
-    include_inactive: bool = False,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.SalesmanListResponse:
-    """List salesmen, optionally including inactive ones.
+    """List all salesmen.
+
+    Filtering by active status is a client-side concern.
 
     Args:
-        include_inactive: When True, inactive salesmen are included.
-            Mirrors the CLI ``--all`` flag. Defaults to False.
         context: Runtime context injected via dependency.
 
     Returns:
-        SalesmanListResponse containing the matching salesman records.
+        SalesmanListResponse containing every salesman record.
     """
-    salesmen = bll.list_salesmen(context, include_inactive=include_inactive)
+    salesmen = bll.list_salesmen(context)
     return schemas.SalesmanListResponse(
         items=[
             schemas.SalesmanResponse(
@@ -46,8 +44,7 @@ def list_salesmen(
 @persistence.mutating_endpoint
 def create_salesman(
     request: schemas.SalesmanCreateRequest,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Create a new salesman.
 
@@ -83,8 +80,7 @@ def create_salesman(
 @persistence.mutating_endpoint
 def deactivate_salesman(
     salesman_id: str,
-    context: bll.RuntimeContext = fastapi.Depends(
-        runtime.get_runtime_context),
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
 ) -> schemas.StandardResponse:
     """Deactivate an existing salesman.
 

--- a/src/caad_erp/bll/products.py
+++ b/src/caad_erp/bll/products.py
@@ -30,57 +30,40 @@ class ProductCommand:
 def _ensure_products_cache(context: runtime.RuntimeContext) -> t.Dict[str, t.Any]:
     """Populate the product cache bucket on demand.
 
-    By storing both the full list and derivative structures, higher-level
-    helpers can service different query patterns without touching the workbook
-    again.
-
     Args:
         context (RuntimeContext): Runtime state used to access the workbook and
             shared caches.
 
     Returns:
-        dict[str, t.Any]: Bucket containing ``all`` products, ``active``
-            products, and a ``by_id`` lookup dictionary. Reuses prior
-            computations when available.
+        dict[str, t.Any]: Bucket containing ``all`` products and a ``by_id``
+            lookup dictionary. Reuses prior computations when available.
     """
 
     bucket = runtime.get_cache_bucket(context, "products")
     if "all" not in bucket:
         all_products = list(dal.iter_products(context.workbook))
         bucket["all"] = all_products
-        bucket["active"] = [
-            product for product in all_products if product.is_active]
-        bucket["by_id"] = {
-            product.product_id: product for product in all_products}
+        bucket["by_id"] = {product.product_id: product for product in all_products}
         logger.debug(
-            "Populated products cache with %d entries (%d active)",
+            "Populated products cache with %d entries",
             len(all_products),
-            len(bucket["active"]),
         )
     return bucket
 
 
-def list_products(context: runtime.RuntimeContext, *, include_inactive: bool = False) -> t.List[dal.ProductRow]:
-    """Return cached product rows optionally filtered by active status.
-
-    The helper interrogates the memoized product bucket so the workbook is not
-    re-scanned between calls. When ``include_inactive`` is ``False`` only rows
-    whose ``ProductRow.is_active`` flag evaluates to ``True`` are returned,
-    preserving the default behavior expected by point-of-sale workflows.
+def list_products(context: runtime.RuntimeContext) -> t.List[dal.ProductRow]:
+    """Return every cached product row.
 
     Args:
         context (RuntimeContext): Runtime context providing workbook access and
             caches.
-        include_inactive (bool): When ``True`` the result includes soft-deleted
-            or inactive products. The default is to surface only active entries.
 
     Returns:
         list[dal.ProductRow]: Copy of the cached product dataset in
             sheet order.
     """
     cache = _ensure_products_cache(context)
-    source = cache["all"] if include_inactive else cache["active"]
-    return list(source)
+    return list(cache["all"])
 
 
 def get_product(context: runtime.RuntimeContext, product_id: str) -> dal.ProductRow:
@@ -107,7 +90,8 @@ def get_product(context: runtime.RuntimeContext, product_id: str) -> dal.Product
     except KeyError as exc:
         logger.warning("Product lookup failed for id '%s'", product_id)
         raise exceptions.MissingReferenceError(
-            f"Unknown product id: {product_id}") from exc
+            f"Unknown product id: {product_id}"
+        ) from exc
 
 
 def update_product(
@@ -133,8 +117,7 @@ def update_product(
     if command.sell_price is not None:
         price = command.sell_price
         if price < 0:
-            logger.error(
-                "Product update rejected: negative sell_price '%s'", price)
+            logger.error("Product update rejected: negative sell_price '%s'", price)
             raise ValueError("Sell price must be zero or positive")
 
         field_values["SellPrice"] = price
@@ -147,12 +130,12 @@ def update_product(
         raise ValueError("At least one field must be provided to update")
 
     try:
-        dal.update_product(
-            context.workbook, normalized_id, field_values=field_values)
+        dal.update_product(context.workbook, normalized_id, field_values=field_values)
     except KeyError as exc:
         logger.warning("Product update failed for id '%s'", normalized_id)
         raise exceptions.MissingReferenceError(
-            f"Unknown product id: {normalized_id}") from exc
+            f"Unknown product id: {normalized_id}"
+        ) from exc
 
     runtime.invalidate_cache(context, "products")
     updated = get_product(context, normalized_id)
@@ -205,8 +188,7 @@ def add_product(
 
     price = command.sell_price
     if price < 0:
-        logger.error(
-            "Product creation rejected: negative sell_price '%s'", price)
+        logger.error("Product creation rejected: negative sell_price '%s'", price)
         raise ValueError("Sell price must be zero or positive")
 
     if command.is_active is None:
@@ -215,10 +197,10 @@ def add_product(
 
     bucket = _ensure_products_cache(context)
     if normalized_id in bucket["by_id"]:
-        logger.error(
-            "Product creation rejected: duplicate id '%s'", normalized_id)
+        logger.error("Product creation rejected: duplicate id '%s'", normalized_id)
         raise exceptions.BusinessRuleViolation(
-            f"Product '{normalized_id}' already exists")
+            f"Product '{normalized_id}' already exists"
+        )
 
     record = dal.ProductRow(
         product_id=normalized_id,

--- a/src/caad_erp/bll/salesmen.py
+++ b/src/caad_erp/bll/salesmen.py
@@ -29,54 +29,42 @@ class SalesmanCommand:
 def _ensure_salesmen_cache(context: runtime.RuntimeContext) -> t.Dict[str, t.Any]:
     """Populate the salesman cache bucket on demand.
 
-    The bucket mirrors the structure used for products so public APIs can rely
-    on a consistent shape when retrieving cached data.
+    The bucket only stores the full dataset and an id-index for lookups.
 
     Args:
         context (RuntimeContext): Runtime state used to access the workbook and
             shared caches.
 
     Returns:
-        dict[str, t.Any]: Bucket containing ``all`` salesmen, ``active`` salesmen,
-            and a ``by_id`` lookup dictionary.
+        dict[str, t.Any]: Bucket containing ``all`` salesmen and a ``by_id``
+            lookup dictionary.
     """
 
     bucket = runtime.get_cache_bucket(context, "salesmen")
     if "all" not in bucket:
         all_salesmen = list(dal.iter_salesmen(context.workbook))
         bucket["all"] = all_salesmen
-        bucket["active"] = [
-            salesman for salesman in all_salesmen if salesman.is_active]
-        bucket["by_id"] = {
-            salesman.salesman_id: salesman for salesman in all_salesmen}
+        bucket["by_id"] = {salesman.salesman_id: salesman for salesman in all_salesmen}
         logger.debug(
-            "Populated salesmen cache with %d entries (%d active)",
+            "Populated salesmen cache with %d entries",
             len(all_salesmen),
-            len(bucket["active"]),
         )
     return bucket
 
 
-def list_salesmen(context: runtime.RuntimeContext, *, include_inactive: bool = False) -> t.List[dal.SalesmanRow]:
-    """Return cached salesman rows optionally filtered by active status.
-
-    Like :func:`list_products`, this helper operates on the memoized salesman
-    bucket to avoid workbook iteration. Callers opt into seeing inactive
-    records when they need historical reporting or audit trails.
+def list_salesmen(context: runtime.RuntimeContext) -> t.List[dal.SalesmanRow]:
+    """Return every cached salesman row.
 
     Args:
         context (RuntimeContext): Runtime context providing workbook access and
             caches.
-        include_inactive (bool): When ``True`` exposes inactive salesmen.
-            Defaults to active-only listings for operational flows.
 
     Returns:
         list[dal.SalesmanRow]: Copy of the cached salesman dataset in
             sheet order.
     """
     cache = _ensure_salesmen_cache(context)
-    source = cache["all"] if include_inactive else cache["active"]
-    return list(source)
+    return list(cache["all"])
 
 
 def get_salesman(context: runtime.RuntimeContext, salesman_id: str) -> dal.SalesmanRow:
@@ -103,7 +91,8 @@ def get_salesman(context: runtime.RuntimeContext, salesman_id: str) -> dal.Sales
     except KeyError as exc:
         logger.warning("Salesman lookup failed for id '%s'", salesman_id)
         raise exceptions.MissingReferenceError(
-            f"Unknown salesman id: {salesman_id}") from exc
+            f"Unknown salesman id: {salesman_id}"
+        ) from exc
 
 
 def add_salesman(
@@ -145,10 +134,10 @@ def add_salesman(
 
     bucket = _ensure_salesmen_cache(context)
     if normalized_id in bucket["by_id"]:
-        logger.error(
-            "Salesman creation rejected: duplicate id '%s'", normalized_id)
+        logger.error("Salesman creation rejected: duplicate id '%s'", normalized_id)
         raise exceptions.BusinessRuleViolation(
-            f"Salesman '{normalized_id}' already exists")
+            f"Salesman '{normalized_id}' already exists"
+        )
 
     record = dal.SalesmanRow(
         salesman_id=normalized_id,
@@ -158,8 +147,9 @@ def add_salesman(
 
     dal.append_salesman(context.workbook, record)
     runtime.invalidate_cache(context, "salesmen")
-    logger.info("Registered salesman '%s' (%s)",
-                record.salesman_id, record.salesman_name)
+    logger.info(
+        "Registered salesman '%s' (%s)", record.salesman_id, record.salesman_name
+    )
     return record
 
 
@@ -191,12 +181,12 @@ def update_salesman(
         raise ValueError("At least one field must be provided to update")
 
     try:
-        dal.update_salesman(
-            context.workbook, normalized_id, field_values=field_values)
+        dal.update_salesman(context.workbook, normalized_id, field_values=field_values)
     except KeyError as exc:
         logger.warning("Salesman update failed for id '%s'", normalized_id)
         raise exceptions.MissingReferenceError(
-            f"Unknown salesman id: {normalized_id}") from exc
+            f"Unknown salesman id: {normalized_id}"
+        ) from exc
 
     runtime.invalidate_cache(context, "salesmen")
     updated = get_salesman(context, normalized_id)

--- a/src/caad_erp/cli/commands/list_products.py
+++ b/src/caad_erp/cli/commands/list_products.py
@@ -28,11 +28,6 @@ def register_list_products_command() -> command_spec.CommandSpec:
                 report command.
         """
         parser = action.add_parser(name, help=help_text)
-        parser.add_argument(
-            "--all",
-            action="store_true",
-            help="Include inactive products in the output.",
-        )
         parser.set_defaults(command=name)
         return parser
 
@@ -45,58 +40,43 @@ def register_list_products_command() -> command_spec.CommandSpec:
     )
 
 
-def _display_products_report(
-    products: t.Iterable[object], *, include_inactive: bool
-) -> None:
+def _display_products_report(products: t.Iterable[object]) -> None:
     """Print product records in a fixed-width table.
 
     Args:
         products (Iterable[object]): Product rows returned by
             :func:`bll.list_products`.
-        include_inactive (bool): Whether inactive products were requested,
-            which controls table columns and empty-state messaging.
     """
     rows = list(products)
     if not rows:
-        print("No products found." if include_inactive else "No active products found.")
+        print("No products found.")
         return
 
-    if include_inactive:
-        print(f"{'Product ID':<20} {'Name':<30} {'Sell Price':>12} {'Active':>7}")
-        print(f"{'-' * 20} {'-' * 30} {'-' * 12} {'-' * 7}")
-        for row in rows:
-            print(
-                f"{getattr(row, 'product_id', ''):<20} "
-                f"{getattr(row, 'product_name', ''):<30} "
-                f"{getattr(row, 'sell_price', 0) / 100:>12.2f} "
-                f"{('yes' if getattr(row, 'is_active', False) else 'no'):>7}"
-            )
-        return
-
-    print(f"{'Product ID':<20} {'Name':<30} {'Sell Price':>12}")
-    print(f"{'-' * 20} {'-' * 30} {'-' * 12}")
+    print(f"{'Product ID':<20} {'Name':<30} {'Sell Price':>12} {'Active':>7}")
+    print(f"{'-' * 20} {'-' * 30} {'-' * 12} {'-' * 7}")
     for row in rows:
         print(
             f"{getattr(row, 'product_id', ''):<20} "
             f"{getattr(row, 'product_name', ''):<30} "
-            f"{getattr(row, 'sell_price', 0) / 100:>12.2f}"
+            f"{getattr(row, 'sell_price', 0) / 100:>12.2f} "
+            f"{('yes' if getattr(row, 'is_active', False) else 'no'):>7}"
         )
 
 
 def _run_list_products_report(
     context: bll.RuntimeContext, args: argparse.Namespace
 ) -> int:
-    """Fetch products and display them on the console.
+    """Fetch all products and display them on the console.
 
     Args:
         context (bll.RuntimeContext): Runtime context used to access workbook
             data and caches.
-        args (argparse.Namespace): Parsed CLI arguments for this command.
+        args (argparse.Namespace): Parsed CLI arguments for this command
+            (currently unused; retained for signature consistency).
 
     Returns:
         int: ``0`` after listing products.
     """
-    include_inactive = bool(getattr(args, "all", False))
-    products = bll.list_products(context, include_inactive=include_inactive)
-    _display_products_report(products, include_inactive=include_inactive)
+    products = bll.list_products(context)
+    _display_products_report(products)
     return 0

--- a/src/caad_erp/cli/commands/list_salesmen.py
+++ b/src/caad_erp/cli/commands/list_salesmen.py
@@ -28,11 +28,6 @@ def register_list_salesmen_command() -> command_spec.CommandSpec:
                 report command.
         """
         parser = action.add_parser(name, help=help_text)
-        parser.add_argument(
-            "--all",
-            action="store_true",
-            help="Include inactive salesmen in the output.",
-        )
         parser.set_defaults(command=name)
         return parser
 
@@ -45,56 +40,42 @@ def register_list_salesmen_command() -> command_spec.CommandSpec:
     )
 
 
-def _display_salesmen_report(
-    salesmen: t.Iterable[object], *, include_inactive: bool
-) -> None:
+def _display_salesmen_report(salesmen: t.Iterable[object]) -> None:
     """Print salesman records in a fixed-width table.
 
     Args:
         salesmen (Iterable[object]): Salesman rows returned by
             :func:`bll.list_salesmen`.
-        include_inactive (bool): Whether inactive salesmen were requested,
-            which controls table columns and empty-state messaging.
     """
     rows = list(salesmen)
     if not rows:
-        print("No salesmen found." if include_inactive else "No active salesmen found.")
+        print("No salesmen found.")
         return
 
-    if include_inactive:
-        print(f"{'Salesman ID':<20} {'Name':<30} {'Active':>7}")
-        print(f"{'-' * 20} {'-' * 30} {'-' * 7}")
-        for row in rows:
-            print(
-                f"{getattr(row, 'salesman_id', ''):<20} "
-                f"{getattr(row, 'salesman_name', ''):<30} "
-                f"{('yes' if getattr(row, 'is_active', False) else 'no'):>7}"
-            )
-        return
-
-    print(f"{'Salesman ID':<20} {'Name':<30}")
-    print(f"{'-' * 20} {'-' * 30}")
+    print(f"{'Salesman ID':<20} {'Name':<30} {'Active':>7}")
+    print(f"{'-' * 20} {'-' * 30} {'-' * 7}")
     for row in rows:
         print(
             f"{getattr(row, 'salesman_id', ''):<20} "
-            f"{getattr(row, 'salesman_name', ''):<30}"
+            f"{getattr(row, 'salesman_name', ''):<30} "
+            f"{('yes' if getattr(row, 'is_active', False) else 'no'):>7}"
         )
 
 
 def _run_list_salesmen_report(
     context: bll.RuntimeContext, args: argparse.Namespace
 ) -> int:
-    """Fetch salesmen and display them on the console.
+    """Fetch all salesmen and display them on the console.
 
     Args:
         context (bll.RuntimeContext): Runtime context used to access workbook
             data and caches.
-        args (argparse.Namespace): Parsed CLI arguments for this command.
+        args (argparse.Namespace): Parsed CLI arguments for this command
+            (currently unused; retained for signature consistency).
 
     Returns:
         int: ``0`` after listing salesmen.
     """
-    include_inactive = bool(getattr(args, "all", False))
-    salesmen = bll.list_salesmen(context, include_inactive=include_inactive)
-    _display_salesmen_report(salesmen, include_inactive=include_inactive)
+    salesmen = bll.list_salesmen(context)
+    _display_salesmen_report(salesmen)
     return 0


### PR DESCRIPTION
Fixes: #32 

This pull request removes server-side filtering for active/inactive products and salesmen, making all filtering a client-side concern. The APIs, CLI, and internal business logic have been updated to always return the full dataset for products and salesmen, simplifying cache structures and removing related parameters and flags. Documentation has also been updated to reflect these changes.

**API and Business Logic Simplification:**

* Removed the `include_inactive` parameter from `list_products` and `list_salesmen` endpoints and their business logic; these endpoints now always return all records, and filtering by active status must be done client-side. (`src/caad_erp/api/routes/products.py`, `src/caad_erp/api/routes/salesmen.py`, `src/caad_erp/bll/products.py`, `src/caad_erp/bll/salesmen.py`) [[1]](diffhunk://#diff-5e5f9984754620ad2d52f566d5eccdb0ec404fab2649f9eacf6bb5a2cba70b14L18-R30) [[2]](diffhunk://#diff-7017ee74120e5301b240edcfa1c4ec5e4c01ac688eabaa6e74a1df2b9688b90eL18-R30) [[3]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL33-R66) [[4]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L32-R67)

* Simplified the product and salesman cache buckets to only store the full list (`all`) and an id-index map (`by_id`), removing the previously memoized `active` subsets. (`src/caad_erp/bll/products.py`, `src/caad_erp/bll/salesmen.py`) [[1]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL33-R66) [[2]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L32-R67)

**CLI Changes:**

* Removed the `--all` flag from the `list-products` CLI command and updated the display logic to always show all products, with the "Active" column always present. (`src/caad_erp/cli/commands/list_products.py`) [[1]](diffhunk://#diff-924304d647201d9f7d35039c515ff7e59e33c3668eaad0d8e02408cd387c92d4L31-L35) [[2]](diffhunk://#diff-924304d647201d9f7d35039c515ff7e59e33c3668eaad0d8e02408cd387c92d4L48-L64)

**Documentation Updates:**

* Updated the developer guide to document that filtering by active status is now a client-side responsibility, and removed references to server-side filtering and related cache structures. (`docs/DEVELOPER_GUIDE.md`) [[1]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L188-R188) [[2]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R334-R343)

**General Code Cleanup:**

* Minor code style improvements and error message formatting for consistency in product and salesman business logic. (`src/caad_erp/bll/products.py`, `src/caad_erp/bll/salesmen.py`) [[1]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL110-R94) [[2]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL136-R120) [[3]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL150-R138) [[4]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL208-R191) [[5]](diffhunk://#diff-7bd748afdec162a105941996955cd4662fee3386771b1cff9acc52311b55461aL218-R203) [[6]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L106-R95) [[7]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L148-R140) [[8]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L161-R152) [[9]](diffhunk://#diff-3290a08c21de0a9296cfdca792fa8eaad633192e2dd19e7b833b62a808513458L194-R189)