### PR TITLE
Fix #35

### DIFF
--- a/src/caad_erp/api/schemas.py
+++ b/src/caad_erp/api/schemas.py
@@ -151,8 +151,8 @@ class TransactionResponse(pydantic.BaseModel):
     transaction_id: str
     timestamp_iso: str
     transaction_type: str
-    product_id: t.Optional[str]
-    salesman_id: t.Optional[str]
+    product_id: str
+    salesman_id: str
     payment_type: t.Optional[str]
     quantity_change: int
     total_revenue: int
@@ -187,8 +187,8 @@ class DebtItem(pydantic.BaseModel):
 
     transaction_id: str
     timestamp_iso: str
-    product_id: t.Optional[str]
-    salesman_id: t.Optional[str]
+    product_id: str
+    salesman_id: str
     quantity: int
     expected_amount: int
     amount_paid: int

--- a/src/caad_erp/bll/reports.py
+++ b/src/caad_erp/bll/reports.py
@@ -24,8 +24,8 @@ class OutstandingDebt:
 
     transaction_id: str
     timestamp_iso: str
-    product_id: t.Optional[str]
-    salesman_id: t.Optional[str]
+    product_id: str
+    salesman_id: str
     quantity: int
     expected_amount: int
     amount_paid: int
@@ -150,17 +150,16 @@ def calculate_outstanding_debts(context: runtime.RuntimeContext) -> t.Dict[str, 
         )
 
         expected_from_price = 0
-        if entry.product_id is not None:
-            try:
-                product = products.get_product(context, entry.product_id)
-            except exceptions.MissingReferenceError:
-                logger.warning(
-                    "Skipping price lookup for missing product '%s' referenced by credit sale '%s'",
-                    entry.product_id,
-                    entry.transaction_id,
-                )
-            else:
-                expected_from_price = product.sell_price * quantity
+        try:
+            product = products.get_product(context, entry.product_id)
+        except exceptions.MissingReferenceError:
+            logger.warning(
+                "Skipping price lookup for missing product '%s' referenced by credit sale '%s'",
+                entry.product_id,
+                entry.transaction_id,
+            )
+        else:
+            expected_from_price = product.sell_price * quantity
 
         expected_amount = (
             expected_from_transaction

--- a/src/caad_erp/bll/transactions.py
+++ b/src/caad_erp/bll/transactions.py
@@ -519,7 +519,13 @@ def record_credit_payment(context: runtime.RuntimeContext, command: CreditPaymen
     return transaction
 
 
-def _build_credit_payment_transaction(command: CreditPaymentCommand, *, transaction_id: str, timestamp: datetime.datetime, product_id: t.Optional[str] = None) -> dal.TransactionRow:
+def _build_credit_payment_transaction(
+    command: CreditPaymentCommand,
+    *,
+    transaction_id: str,
+    timestamp: datetime.datetime,
+    product_id: str,
+) -> dal.TransactionRow:
     """Materialize a :class:`CreditPaymentCommand` into a DAL transaction row.
 
     Args:
@@ -527,8 +533,7 @@ def _build_credit_payment_transaction(command: CreditPaymentCommand, *, transact
             payment.
         transaction_id (str): Unique identifier allocated for the transaction.
         timestamp (datetime): Timestamp assigned to the transaction.
-        product_id (str | None): t.Optional product identifier inferred from the
-            linked sale.
+        product_id (str): Product identifier inferred from the linked sale.
 
     Returns:
         dal.TransactionRow: Row ready for persistence via the data

--- a/src/caad_erp/cli/commands/debts.py
+++ b/src/caad_erp/cli/commands/debts.py
@@ -68,10 +68,8 @@ def _display_debts_report(summary: t.Mapping[str, t.Any]) -> None:
     print("-" * len(header))
 
     for entry in balances:
-        product = entry.product_id or "-"
-        salesman = entry.salesman_id or "-"
         print(
-            f"{entry.transaction_id:<18} {product:<12} {salesman:<12} "
+            f"{entry.transaction_id:<18} {entry.product_id:<12} {entry.salesman_id:<12} "
             f"{entry.quantity:>9} {entry.expected_amount / 100:>10.2f} "
             f"{entry.amount_paid / 100:>10.2f} {entry.balance / 100:>10.2f}"
         )

--- a/src/caad_erp/cli/commands/log.py
+++ b/src/caad_erp/cli/commands/log.py
@@ -62,8 +62,8 @@ def _display_transaction_log(transactions: t.Iterable[object]) -> None:
     print("-" * len(header))
 
     for transaction in transactions:
-        product = getattr(transaction, "product_id", None) or "-"
-        salesman = getattr(transaction, "salesman_id", None) or "-"
+        product = getattr(transaction, "product_id", "")
+        salesman = getattr(transaction, "salesman_id", "")
         timestamp_raw = getattr(transaction, "timestamp_iso", "") or ""
         timestamp = timestamp_raw[:19]
         notes = getattr(transaction, "notes", None) or ""

--- a/src/caad_erp/dal/transactions.py
+++ b/src/caad_erp/dal/transactions.py
@@ -27,8 +27,8 @@ class TransactionRow:
     transaction_id: str
     timestamp_iso: str
     transaction_type: str
-    product_id: t.Optional[str]
-    salesman_id: t.Optional[str]
+    product_id: str
+    salesman_id: str
     payment_type: t.Optional[str]
     quantity_change: int
     total_revenue: int
@@ -104,9 +104,11 @@ def _serialize_transaction(record: TransactionRow) -> list[object]:
 def _deserialize_transaction(raw_row: t.Sequence[object]) -> TransactionRow:
     """Convert a raw worksheet row into a strongly typed transaction record.
 
-    Optional columns remain ``None`` when the sheet leaves them blank, and
-    textual columns default to empty strings to avoid ``None`` values where
-    downstream code expects text.
+    ``ProductID`` and ``SalesmanID`` are required for every transaction and are
+    always coerced to strings. The remaining optional columns (``PaymentType``,
+    ``LinkedTransactionID``, ``Notes``) remain ``None`` when the sheet leaves
+    them blank, and required textual columns default to empty strings to avoid
+    ``None`` values where downstream code expects text.
 
     Args:
         raw_row (Sequence[object]): Raw cell values from the transaction log row
@@ -141,8 +143,8 @@ def _deserialize_transaction(raw_row: t.Sequence[object]) -> TransactionRow:
         transaction_id=str(transaction_id),
         timestamp_iso=str(timestamp_iso) if timestamp_iso is not None else "",
         transaction_type=str(transaction_type) if transaction_type is not None else "",
-        product_id=str(product_id) if product_id is not None else None,
-        salesman_id=str(salesman_id) if salesman_id is not None else None,
+        product_id=str(product_id),
+        salesman_id=str(salesman_id),
         payment_type=str(payment_type) if payment_type is not None else None,
         quantity_change=quantity_change,
         total_revenue=total_revenue,

--- a/tests/cli/commands/test_log.py
+++ b/tests/cli/commands/test_log.py
@@ -18,19 +18,21 @@ def _make_context(tmp_path: Path) -> bll.RuntimeContext:
     salesmen = wb.create_sheet(constants.SheetName.SALESMEN.value)
     salesmen.append(["SalesmanID", "SalesmanName", "IsActive"])
     tx = wb.create_sheet(constants.SheetName.TRANSACTION_LOG.value)
-    tx.append([
-        "TransactionID",
-        "Timestamp",
-        "TransactionType",
-        "ProductID",
-        "SalesmanID",
-        "PaymentType",
-        "QuantityChange",
-        "TotalRevenue",
-        "TotalCost",
-        "LinkedTransactionID",
-        "Notes",
-    ])
+    tx.append(
+        [
+            "TransactionID",
+            "Timestamp",
+            "TransactionType",
+            "ProductID",
+            "SalesmanID",
+            "PaymentType",
+            "QuantityChange",
+            "TotalRevenue",
+            "TotalCost",
+            "LinkedTransactionID",
+            "Notes",
+        ]
+    )
     settings = AppSettings(
         data_file=tmp_path / "data.xlsx",
         lounge_name="Test",
@@ -89,7 +91,7 @@ def test_display_transaction_log_prints_empty_message_for_no_entries(capsys) -> 
 @pytest.mark.parametrize("notes_value", [None, "", "short", "x" * 60])
 def test_display_transaction_log_formats_rows_and_notes(notes_value, capsys) -> None:
     """
-    GIVEN transaction rows with optional product salesman timestamp and notes values
+    GIVEN transaction rows with optional notes values
     WHEN _display_transaction_log is called
     THEN row formatting applies defaults timestamp truncation and notes truncation rules
     """
@@ -98,8 +100,8 @@ def test_display_transaction_log_formats_rows_and_notes(notes_value, capsys) -> 
         transaction_id="T1",
         timestamp_iso="2026-03-15T10:00:00+00:00",
         transaction_type=constants.TransactionType.SALE.value,
-        product_id=None,
-        salesman_id=None,
+        product_id="P001",
+        salesman_id="S001",
         payment_type=constants.PaymentType.CASH.value,
         quantity_change=-1,
         total_revenue=250,

--- a/tests/dal/test_transactions.py
+++ b/tests/dal/test_transactions.py
@@ -8,8 +8,8 @@ def _sample_transaction(
     transaction_id: str = "T-001",
     timestamp_iso: str = "2026-03-15T12:00:00",
     transaction_type: str = "SALE",
-    product_id: str | None = "P-001",
-    salesman_id: str | None = "S-001",
+    product_id: str = "P-001",
+    salesman_id: str = "S-001",
     payment_type: str | None = "Cash",
     quantity_change: int = -1,
     total_revenue: int = 550,
@@ -125,8 +125,8 @@ def test_iter_transactions_optional_fields_are_none_when_blank(transactions_work
             "T-001",
             "2026-03-15T12:00:00",
             "SALE",
-            None,
-            None,
+            "P-001",
+            "S-001",
             None,
             -1,
             0,
@@ -140,8 +140,6 @@ def test_iter_transactions_optional_fields_are_none_when_blank(transactions_work
     record = list(transactions.iter_transactions(transactions_workbook))[0]
 
     # Assert
-    assert record.product_id is None
-    assert record.salesman_id is None
     assert record.payment_type is None
     assert record.linked_transaction_id is None
     assert record.notes is None
@@ -251,8 +249,6 @@ def test_append_transaction_stores_none_for_optional_fields(transactions_workboo
     """
     # Arrange
     record = _sample_transaction(
-        product_id=None,
-        salesman_id=None,
         payment_type=None,
         linked_transaction_id=None,
         notes=None,
@@ -263,8 +259,6 @@ def test_append_transaction_stores_none_for_optional_fields(transactions_workboo
     row = list(transactions_workbook["TransactionLog"].iter_rows(min_row=2, values_only=True))[0]
 
     # Assert
-    assert row[3] is None
-    assert row[4] is None
     assert row[5] is None
     assert row[9] is None
     assert row[10] is None
@@ -332,8 +326,6 @@ def test_serialize_transaction_preserves_none_for_optional_fields() -> None:
     """
     # Arrange
     record = _sample_transaction(
-        product_id=None,
-        salesman_id=None,
         payment_type=None,
         linked_transaction_id=None,
         notes=None,
@@ -343,8 +335,6 @@ def test_serialize_transaction_preserves_none_for_optional_fields() -> None:
     serialized = transactions._serialize_transaction(record)
 
     # Assert
-    assert serialized[3] is None
-    assert serialized[4] is None
     assert serialized[5] is None
     assert serialized[9] is None
     assert serialized[10] is None
@@ -404,14 +394,12 @@ def test_deserialize_transaction_preserves_none_for_optional_text_fields() -> No
     THEN optional fields remain None
     """
     # Arrange
-    raw_row = ["T-001", "2026-03-15T12:00:00", "SALE", None, None, None, -1, 0, 0, None, None]
+    raw_row = ["T-001", "2026-03-15T12:00:00", "SALE", "P-001", "S-001", None, -1, 0, 0, None, None]
 
     # Act
     result = transactions._deserialize_transaction(raw_row)
 
     # Assert
-    assert result.product_id is None
-    assert result.salesman_id is None
     assert result.payment_type is None
     assert result.linked_transaction_id is None
     assert result.notes is None


### PR DESCRIPTION
This pull request makes `product_id` and `salesman_id` required fields across the transaction data models and related code, removing their previous optional status. This change affects the data layer, business logic, CLI output, and test cases to ensure that every transaction must always include both a product and a salesman identifier.

Key changes include:

**Data Model Changes:**

* Made `product_id` and `salesman_id` required (non-optional) in `TransactionRow`, `TransactionResponse`, and `DebtItem` models in `src/caad_erp/dal/transactions.py` and `src/caad_erp/api/schemas.py`. [[1]](diffhunk://#diff-ab02e0120f08edbd5d0056d62b3d22b7eebec11c673f6df22663a1d66ef1cf8cL30-R31) [[2]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6L154-R155) [[3]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6L190-R191)
* Updated the deserialization logic to always coerce these fields to strings, and clarified documentation that they are now required for every transaction. [[1]](diffhunk://#diff-ab02e0120f08edbd5d0056d62b3d22b7eebec11c673f6df22663a1d66ef1cf8cL107-R111) [[2]](diffhunk://#diff-ab02e0120f08edbd5d0056d62b3d22b7eebec11c673f6df22663a1d66ef1cf8cL144-R147)

**Business Logic Updates:**

* Updated the outstanding debts and credit payment transaction logic to require `product_id` and `salesman_id`, removing checks for `None` values and updating function signatures accordingly in `src/caad_erp/bll/reports.py` and `src/caad_erp/bll/transactions.py`. [[1]](diffhunk://#diff-4562a4f9e39af73fa0d4b8605f81a566db1c806b2fdc26d62242e4a88ace79bdL27-R28) [[2]](diffhunk://#diff-4562a4f9e39af73fa0d4b8605f81a566db1c806b2fdc26d62242e4a88ace79bdL153) [[3]](diffhunk://#diff-905037df566e4f5a29a1a6f0c72e162719801a234e6af294dbfce25fd48711c7L522-R536)

**CLI and Output Formatting:**

* Simplified CLI output formatting by removing fallback values for missing `product_id` and `salesman_id`, since these fields are now guaranteed to be present. [[1]](diffhunk://#diff-75a4471881e802422e1badc13324499e0611986bbef7d7af32f9ce67b56c1832L71-R72) [[2]](diffhunk://#diff-431ab460732d6d96df28d324490b0e6d03285ebdb497bfb073515c38156b9169L65-R66)

**Test Suite Adjustments:**

* Updated test data and assertions to reflect that `product_id` and `salesman_id` cannot be `None`, and removed tests that assumed these fields could be missing. [[1]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L11-R12) [[2]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L128-R129) [[3]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L143-L144) [[4]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L254-L255) [[5]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L266-L267) [[6]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L335-L336) [[7]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L346-L347) [[8]](diffhunk://#diff-98bd921632faec654ee478cd1b59c199700c9c3c86b6fb5e8c97ee6a187d7bb9L407-L414) [[9]](diffhunk://#diff-ed416cab79c1407632dc694eaadcc9c630e16d58a757e7a8d63e72266466424cL101-R104)

**Other Minor Cleanups:**

* Updated test and documentation strings to remove references to optionality of `product_id` and `salesman_id`.

These changes enforce stricter data integrity by ensuring every transaction is always associated with a product and a salesman.