### PR TITLE
Fix #26

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -208,11 +208,13 @@ the "N+1" read pattern during operations.
 
 ## Error handling in the CLI
 
-(#TODO)
+CLI command handlers wrap execution routines in exception handling logic that maps domain and system exceptions to standardized exit codes via `handle_cli_error`. When an exception occurs, the error message is output to standard error (`sys.stderr`) to provide user feedback, and the corresponding non-zero exit code is returned to the caller or shell environment.
 
-Each command exits with `0` on success, `2` for business rule violations, `3`
-when the configuration or data file cannot be found, and `1` for unexpected
-errors.
+Exit code mapping:
+- `0`: Operation succeeded cleanly.
+- `1`: Generic unexpected runtime error (e.g. `RuntimeError`, `ValueError`).
+- `2`: Business rule violation or domain constraint failure (`BusinessRuleViolation` or `MissingReferenceError`).
+- `3`: Missing configuration or data file (`FileNotFoundError`).
 
 ## Tests
 

--- a/src/caad_erp/cli/commands/add_product.py
+++ b/src/caad_erp/cli/commands/add_product.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_add_product_command() -> command_spec.CommandSpec:
@@ -79,9 +80,11 @@ def _run_add_product(context: bll.RuntimeContext, args: argparse.Namespace) -> i
             input for the ``add-product`` command.
 
     Returns:
-        int: Exit code ``0`` on success. Errors are propagated for higher level
-            handling.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_add_product(args)
-    bll.add_product(context, command)
-    return 0
+    try:
+        command = _translate_add_product(args)
+        bll.add_product(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/add_salesman.py
+++ b/src/caad_erp/cli/commands/add_salesman.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_add_salesman_command() -> command_spec.CommandSpec:
@@ -71,8 +72,11 @@ def _run_add_salesman(context: bll.RuntimeContext, args: argparse.Namespace) -> 
         args (argparse.Namespace): Parsed CLI arguments for the command.
 
     Returns:
-        int: Exit code ``0`` when the salesman is successfully recorded.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_add_salesman(args)
-    bll.add_salesman(context, command)
-    return 0
+    try:
+        command = _translate_add_salesman(args)
+        bll.add_salesman(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/debts.py
+++ b/src/caad_erp/cli/commands/debts.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_debts_command() -> command_spec.CommandSpec:
@@ -88,9 +89,12 @@ def _run_debts_report(context: bll.RuntimeContext, args: argparse.Namespace) -> 
             retained for API consistency.
 
     Returns:
-        int: ``0`` once the debts summary has been calculated and displayed.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
 
-    summary = bll.calculate_outstanding_debts(context)
-    _display_debts_report(summary)
-    return 0
+    try:
+        summary = bll.calculate_outstanding_debts(context)
+        _display_debts_report(summary)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/edit_product.py
+++ b/src/caad_erp/cli/commands/edit_product.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def _str_to_bool(value: str) -> bool:
@@ -80,9 +81,12 @@ def _run_edit_product(context: bll.RuntimeContext, args: argparse.Namespace) -> 
         args (argparse.Namespace): Parsed CLI arguments for the command.
 
     Returns:
-        int: Exit code ``0`` after the product has been altered.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
 
-    command = _translate_edit_product(args)
-    bll.update_product(context, command)
-    return 0
+    try:
+        command = _translate_edit_product(args)
+        bll.update_product(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/edit_salesman.py
+++ b/src/caad_erp/cli/commands/edit_salesman.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def _str_to_bool(value: str) -> bool:
@@ -83,9 +84,12 @@ def _run_edit_salesman(context: bll.RuntimeContext, args: argparse.Namespace) ->
         args (argparse.Namespace): Parsed CLI arguments for the command.
 
     Returns:
-        int: Exit code ``0`` after the salesman has been altered.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
 
-    command = _translate_edit_salesman(args)
-    bll.update_salesman(context, command)
-    return 0
+    try:
+        command = _translate_edit_salesman(args)
+        bll.update_salesman(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/list_products.py
+++ b/src/caad_erp/cli/commands/list_products.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_list_products_command() -> command_spec.CommandSpec:
@@ -81,13 +82,16 @@ def _run_list_products_report(
             (currently unused; retained for signature consistency).
 
     Returns:
-        int: ``0`` after listing products.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
-    products = bll.list_products(context)
-    product = (
-        products
-        if not args.product_id
-        else [product for product in products if product.product_id == args.product_id]
-    )
-    _display_products_report(product)
-    return 0
+    try:
+        products = bll.list_products(context)
+        product = (
+            products
+            if not args.product_id
+            else [product for product in products if product.product_id == args.product_id]
+        )
+        _display_products_report(product)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/list_salesmen.py
+++ b/src/caad_erp/cli/commands/list_salesmen.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_list_salesmen_command() -> command_spec.CommandSpec:
@@ -80,17 +81,20 @@ def _run_list_salesmen_report(
             (currently unused; retained for signature consistency).
 
     Returns:
-        int: ``0`` after listing salesmen.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
-    salesmen = bll.list_salesmen(context)
-    salesman = (
-        salesmen
-        if not args.salesman_id
-        else [
-            salesman
-            for salesman in salesmen
-            if salesman.salesman_id == args.salesman_id
-        ]
-    )
-    _display_salesmen_report(salesman)
-    return 0
+    try:
+        salesmen = bll.list_salesmen(context)
+        salesman = (
+            salesmen
+            if not args.salesman_id
+            else [
+                salesman
+                for salesman in salesmen
+                if salesman.salesman_id == args.salesman_id
+            ]
+        )
+        _display_salesmen_report(salesman)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/log.py
+++ b/src/caad_erp/cli/commands/log.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_log_command() -> command_spec.CommandSpec:
@@ -88,9 +89,12 @@ def _run_log_report(context: bll.RuntimeContext, args: argparse.Namespace) -> in
             symmetry with other commands and currently unused.
 
     Returns:
-        int: ``0`` after listing the transactions.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
 
-    transactions = bll.list_transactions(context)
-    _display_transaction_log(transactions)
-    return 0
+    try:
+        transactions = bll.list_transactions(context)
+        _display_transaction_log(transactions)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/pay_debt.py
+++ b/src/caad_erp/cli/commands/pay_debt.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll, constants
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_pay_debt_command() -> command_spec.CommandSpec:
@@ -87,8 +88,11 @@ def _run_pay_debt(context: bll.RuntimeContext, args: argparse.Namespace) -> int:
             payment.
 
     Returns:
-        int: Exit code ``0`` when the payment is recorded successfully.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_pay_debt(args)
-    bll.record_credit_payment(context, command)
-    return 0
+    try:
+        command = _translate_pay_debt(args)
+        bll.record_credit_payment(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/profit.py
+++ b/src/caad_erp/cli/commands/profit.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_profit_command() -> command_spec.CommandSpec:
@@ -69,9 +70,12 @@ def _run_profit_report(context: bll.RuntimeContext, args: argparse.Namespace) ->
             options and currently unused.
 
     Returns:
-        int: ``0`` after the summary has been printed.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
 
-    summary = bll.calculate_profit_summary(context)
-    _display_profit_summary(summary)
-    return 0
+    try:
+        summary = bll.calculate_profit_summary(context)
+        _display_profit_summary(summary)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/restock.py
+++ b/src/caad_erp/cli/commands/restock.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_restock_command() -> command_spec.CommandSpec:
@@ -74,10 +75,11 @@ def _run_restock(context: bll.RuntimeContext, args: argparse.Namespace) -> int:
             restock operation.
 
     Returns:
-        int: Exit code ``0`` when the restock is recorded successfully.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_restock(args)
-    # TODO: Need to return error when the restock fails
-    # For example, on inactive salesman
-    bll.record_restock(context, command)
-    return 0
+    try:
+        command = _translate_restock(args)
+        bll.record_restock(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/sale.py
+++ b/src/caad_erp/cli/commands/sale.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll, constants
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_sale_command() -> command_spec.CommandSpec:
@@ -84,8 +85,11 @@ def _run_sale(context: bll.RuntimeContext, args: argparse.Namespace) -> int:
             operation.
 
     Returns:
-        int: Exit code ``0`` when the sale is recorded successfully.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_sale(args)
-    bll.record_sale(context, command)
-    return 0
+    try:
+        command = _translate_sale(args)
+        bll.record_sale(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/stock.py
+++ b/src/caad_erp/cli/commands/stock.py
@@ -4,6 +4,7 @@ import typing as t
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_stock_command() -> command_spec.CommandSpec:
@@ -68,10 +69,12 @@ def _run_stock_report(context: bll.RuntimeContext, args: argparse.Namespace) -> 
             symmetry with other commands, currently unused.
 
     Returns:
-        int: ``0`` after delegating to the business layer and printing the
-        inventory snapshot.
+        int: ``0`` on success, or a non-zero exit code on failure.
     """
 
-    inventory = bll.calculate_inventory(context)
-    _display_inventory_report(inventory)
-    return 0
+    try:
+        inventory = bll.calculate_inventory(context)
+        _display_inventory_report(inventory)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/void.py
+++ b/src/caad_erp/cli/commands/void.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_void_command() -> command_spec.CommandSpec:
@@ -63,8 +64,11 @@ def _run_void(context: bll.RuntimeContext, args: argparse.Namespace) -> int:
             operation.
 
     Returns:
-        int: Exit code ``0`` when the void is recorded successfully.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_void(args)
-    bll.record_void(context, command)
-    return 0
+    try:
+        command = _translate_void(args)
+        bll.record_void(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/commands/write_off.py
+++ b/src/caad_erp/cli/commands/write_off.py
@@ -3,6 +3,7 @@ import argparse
 from caad_erp import bll
 
 from .. import command_spec
+from ..parser import handle_cli_error
 
 
 def register_write_off_command() -> command_spec.CommandSpec:
@@ -72,8 +73,11 @@ def _run_write_off(context: bll.RuntimeContext, args: argparse.Namespace) -> int
             write-off operation.
 
     Returns:
-        int: Exit code ``0`` when the write-off is recorded successfully.
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
     """
-    command = _translate_write_off(args)
-    bll.record_write_off(context, command)
-    return 0
+    try:
+        command = _translate_write_off(args)
+        bll.record_write_off(context, command)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/src/caad_erp/cli/parser.py
+++ b/src/caad_erp/cli/parser.py
@@ -9,6 +9,7 @@ import argparse
 import importlib
 import logging
 import pkgutil
+import sys
 import typing as t
 from pathlib import Path
 
@@ -200,11 +201,14 @@ def handle_cli_error(error: Exception) -> int:
     """
     if isinstance(error, exceptions.BusinessRuleViolation):
         logger.error("%s", error)
+        print(f"Error: {error}")
         return 2
     if isinstance(error, FileNotFoundError):
         logger.error("%s", error)
+        print(f"Error: {error}")
         return 3
     logger.error("%s", error)
+    print(f"Error: {error}")
     return 1
 
 

--- a/tests/cli/commands/test_add_product.py
+++ b/tests/cli/commands/test_add_product.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import add_product
 from caad_erp.settings import AppSettings
 
@@ -143,3 +143,32 @@ def test_run_add_product_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     created = bll.get_product(context, "P001")
     assert created.product_name == "Cookie"
     assert created.sell_price == 250
+
+
+def test_run_add_product_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and add-product args when bll raises BusinessRuleViolation
+    WHEN _run_add_product is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        product_id="P001",
+        product_name="Cookie",
+        sell_price=250,
+        inactive=False,
+    )
+
+    def _mock_add_product(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Duplicate product")
+
+    monkeypatch.setattr(bll, "add_product", _mock_add_product)
+
+    # Act
+    exit_code = add_product._run_add_product(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_add_salesman.py
+++ b/tests/cli/commands/test_add_salesman.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import add_salesman
 from caad_erp.settings import AppSettings
 
@@ -135,3 +135,31 @@ def test_run_add_salesman_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     assert exit_code == 0
     created = bll.get_salesman(context, "S001")
     assert created.salesman_name == "Ana"
+
+
+def test_run_add_salesman_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and add-salesman args when bll raises BusinessRuleViolation
+    WHEN _run_add_salesman is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        salesman_id="S001",
+        salesman_name="Ana",
+        inactive=False,
+    )
+
+    def _mock_add_salesman(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Duplicate salesman")
+
+    monkeypatch.setattr(bll, "add_salesman", _mock_add_salesman)
+
+    # Act
+    exit_code = add_salesman._run_add_salesman(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_debts.py
+++ b/tests/cli/commands/test_debts.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, dal, exceptions
 from caad_erp.cli.commands import debts
 from caad_erp.settings import AppSettings
 
@@ -161,3 +161,26 @@ def test_run_debts_report_calls_bll_and_returns_zero(tmp_path: Path, capsys) -> 
     # Assert
     assert exit_code == 0
     assert "Outstanding credit balances:" in capsys.readouterr().out
+
+
+def test_run_debts_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_debts_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+
+    def _mock_calculate_debts(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Calculation failed")
+
+    monkeypatch.setattr(bll, "calculate_outstanding_debts", _mock_calculate_debts)
+
+    # Act
+    exit_code = debts._run_debts_report(context, argparse.Namespace())
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_edit_product.py
+++ b/tests/cli/commands/test_edit_product.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import edit_product
 from caad_erp.settings import AppSettings
 
@@ -137,3 +138,32 @@ def test_run_edit_product_calls_bll_update_and_returns_zero(tmp_path: Path) -> N
     assert updated.product_name == "New Cookie"
     assert updated.sell_price == 300
     assert updated.is_active is False
+
+
+def test_run_edit_product_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and edit-product args when bll raises BusinessRuleViolation
+    WHEN _run_edit_product is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        product_id="P999",
+        product_name="New Name",
+        product_sell_price=None,
+        product_is_active=None,
+    )
+
+    def _mock_update_product(*args, **kwargs):
+        raise exceptions.MissingReferenceError("Product not found")
+
+    monkeypatch.setattr(bll, "update_product", _mock_update_product)
+
+    # Act
+    exit_code = edit_product._run_edit_product(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_edit_salesman.py
+++ b/tests/cli/commands/test_edit_salesman.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import edit_salesman
 from caad_erp.settings import AppSettings
 
@@ -126,3 +127,31 @@ def test_run_edit_salesman_calls_bll_update_and_returns_zero(tmp_path: Path) -> 
     updated = bll.get_salesman(context, "S001")
     assert updated.salesman_name == "John"
     assert updated.is_active is False
+
+
+def test_run_edit_salesman_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and edit-salesman args when bll raises BusinessRuleViolation
+    WHEN _run_edit_salesman is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        salesman_id="S999",
+        salesman_name="New Name",
+        salesman_is_active=None,
+    )
+
+    def _mock_update_salesman(*args, **kwargs):
+        raise exceptions.MissingReferenceError("Salesman not found")
+
+    monkeypatch.setattr(bll, "update_salesman", _mock_update_salesman)
+
+    # Act
+    exit_code = edit_salesman._run_edit_salesman(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_list_products.py
+++ b/tests/cli/commands/test_list_products.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import list_products
 from caad_erp.settings import AppSettings
 
@@ -99,3 +100,27 @@ def test_run_list_products_report_reports_only_specific_product(
     output = capsys.readouterr().out
     assert "P001" in output
     assert "P002" not in output
+
+
+def test_run_list_products_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_list_products_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(product_id=None)
+
+    def _mock_list_products(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Product list error")
+
+    monkeypatch.setattr(bll, "list_products", _mock_list_products)
+
+    # Act
+    exit_code = list_products._run_list_products_report(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_list_salesmen.py
+++ b/tests/cli/commands/test_list_salesmen.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import list_salesmen
 from caad_erp.settings import AppSettings
 
@@ -99,3 +100,27 @@ def test_run_list_salesmen_report_reports_only_specific_salesman(
     output = capsys.readouterr().out
     assert "S001" in output
     assert "S002" not in output
+
+
+def test_run_list_salesmen_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_list_salesmen_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(salesman_id=None)
+
+    def _mock_list_salesmen(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Salesman list error")
+
+    monkeypatch.setattr(bll, "list_salesmen", _mock_list_salesmen)
+
+    # Act
+    exit_code = list_salesmen._run_list_salesmen_report(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_log.py
+++ b/tests/cli/commands/test_log.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, dal, exceptions
 from caad_erp.cli.commands import log
 from caad_erp.settings import AppSettings
 
@@ -152,3 +152,26 @@ def test_run_log_report_calls_bll_and_returns_zero(tmp_path: Path, capsys) -> No
     # Assert
     assert exit_code == 0
     assert "Transaction log:" in capsys.readouterr().out
+
+
+def test_run_log_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_log_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+
+    def _mock_list_transactions(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Log error")
+
+    monkeypatch.setattr(bll, "list_transactions", _mock_list_transactions)
+
+    # Act
+    exit_code = log._run_log_report(context, argparse.Namespace())
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_pay_debt.py
+++ b/tests/cli/commands/test_pay_debt.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, exceptions, dal
 from caad_erp.cli.commands import pay_debt
 from caad_erp.settings import AppSettings
 
@@ -179,3 +179,33 @@ def test_run_pay_debt_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     rows = bll.list_transactions(context)
     assert len(rows) == 2
     assert rows[-1].transaction_type == constants.TransactionType.CREDIT_PAYMENT.value
+
+
+def test_run_pay_debt_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and pay-debt args when bll raises BusinessRuleViolation
+    WHEN _run_pay_debt is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        linked_transaction_id="TX999",
+        salesman_id="S001",
+        total_revenue=500,
+        payment_type=constants.PaymentType.CASH.value,
+        notes=None,
+    )
+
+    def _mock_pay_debt(*args, **kwargs):
+        raise exceptions.MissingReferenceError("Unknown transaction")
+
+    monkeypatch.setattr(bll, "record_credit_payment", _mock_pay_debt)
+
+    # Act
+    exit_code = pay_debt._run_pay_debt(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_profit.py
+++ b/tests/cli/commands/test_profit.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, dal, exceptions
 from caad_erp.cli.commands import profit
 from caad_erp.settings import AppSettings
 
@@ -136,3 +136,26 @@ def test_run_profit_report_calls_bll_and_returns_zero(tmp_path: Path, capsys) ->
     # Assert
     assert exit_code == 0
     assert "Profit summary" in capsys.readouterr().out
+
+
+def test_run_profit_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_profit_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+
+    def _mock_profit_summary(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Profit calculation error")
+
+    monkeypatch.setattr(bll, "calculate_profit_summary", _mock_profit_summary)
+
+    # Act
+    exit_code = profit._run_profit_report(context, argparse.Namespace())
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_restock.py
+++ b/tests/cli/commands/test_restock.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import restock
 from caad_erp.settings import AppSettings
 
@@ -113,3 +114,33 @@ def test_run_restock_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     rows = bll.list_transactions(context)
     assert len(rows) == 1
     assert rows[0].transaction_type == constants.TransactionType.RESTOCK.value
+
+
+def test_run_restock_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and restock args when bll raises BusinessRuleViolation
+    WHEN _run_restock is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        product_id="P001",
+        quantity="5",
+        total_cost="1000",
+        salesman_id="INACTIVE_S",
+        notes=None,
+    )
+
+    def _mock_record_restock(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Inactive salesman")
+
+    monkeypatch.setattr(bll, "record_restock", _mock_record_restock)
+
+    # Act
+    exit_code = restock._run_restock(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_sale.py
+++ b/tests/cli/commands/test_sale.py
@@ -4,7 +4,7 @@ import argparse
 import openpyxl
 import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import sale
 from caad_erp.settings import AppSettings
 
@@ -165,3 +165,34 @@ def test_run_sale_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     rows = bll.list_transactions(context)
     assert len(rows) == 1
     assert rows[0].transaction_type == constants.TransactionType.SALE.value
+
+
+def test_run_sale_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and sale args when bll raises BusinessRuleViolation
+    WHEN _run_sale is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        product_id="UNKNOWN",
+        quantity="2",
+        salesman_id="S001",
+        total_revenue=500,
+        payment_type=constants.PaymentType.CASH.value,
+        notes=None,
+    )
+
+    def _mock_record_sale(*args, **kwargs):
+        raise exceptions.MissingReferenceError("Unknown product")
+
+    monkeypatch.setattr(bll, "record_sale", _mock_record_sale)
+
+    # Act
+    exit_code = sale._run_sale(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_stock.py
+++ b/tests/cli/commands/test_stock.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, dal, exceptions
 from caad_erp.cli.commands import stock
 from caad_erp.settings import AppSettings
 
@@ -136,3 +137,26 @@ def test_run_stock_report_calls_bll_and_returns_zero(tmp_path: Path, capsys) -> 
     # Assert
     assert exit_code == 0
     assert "P001" in capsys.readouterr().out
+
+
+def test_run_stock_report_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context when bll raises BusinessRuleViolation
+    WHEN _run_stock_report is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+
+    def _mock_calculate_inventory(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Stock calculation error")
+
+    monkeypatch.setattr(bll, "calculate_inventory", _mock_calculate_inventory)
+
+    # Act
+    exit_code = stock._run_stock_report(context, argparse.Namespace())
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_void.py
+++ b/tests/cli/commands/test_void.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants, dal
+from caad_erp import bll, constants, dal, exceptions
 from caad_erp.cli.commands import void
 from caad_erp.settings import AppSettings
 
@@ -128,3 +129,27 @@ def test_run_void_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     rows = bll.list_transactions(context)
     assert len(rows) == 2
     assert rows[-1].transaction_type == constants.TransactionType.VOID.value
+
+
+def test_run_void_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and void args when bll raises BusinessRuleViolation
+    WHEN _run_void is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(linked_transaction_id="TX999", notes=None)
+
+    def _mock_record_void(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Cannot void transaction")
+
+    monkeypatch.setattr(bll, "record_void", _mock_record_void)
+
+    # Act
+    exit_code = void._run_void(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/cli/commands/test_write_off.py
+++ b/tests/cli/commands/test_write_off.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import argparse
 import openpyxl
+import pytest
 
-from caad_erp import bll, constants
+from caad_erp import bll, constants, exceptions
 from caad_erp.cli.commands import write_off
 from caad_erp.settings import AppSettings
 
@@ -110,3 +111,32 @@ def test_run_write_off_calls_bll_and_returns_zero(tmp_path: Path) -> None:
     rows = bll.list_transactions(context)
     assert len(rows) == 1
     assert rows[0].transaction_type == constants.TransactionType.WRITE_OFF.value
+
+
+def test_run_write_off_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and write-off args when bll raises BusinessRuleViolation
+    WHEN _run_write_off is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        product_id="P001",
+        quantity="1",
+        salesman_id="S001",
+        notes=None,
+    )
+
+    def _mock_record_write_off(*args, **kwargs):
+        raise exceptions.BusinessRuleViolation("Product inactive")
+
+    monkeypatch.setattr(bll, "record_write_off", _mock_record_write_off)
+
+    # Act
+    exit_code = write_off._run_write_off(context, args)
+
+    # Assert
+    assert exit_code == 2


### PR DESCRIPTION
Fixes #26 

This pull request introduces standardized exception handling across all CLI command handlers, ensuring consistent user feedback and exit codes for various error scenarios. The implementation wraps each command's execution in a `try/except` block and delegates error handling to a new `handle_cli_error` function, which outputs user-friendly error messages and returns appropriate exit codes. Additionally, the developer guide has been updated to document this behavior.

**CLI Exception Handling Standardization**

* All CLI command handlers (e.g., `add_product`, `edit_product`, `sale`, `restock`, etc.) now wrap their core logic in `try/except` blocks, calling `handle_cli_error` to process exceptions and return standardized exit codes. This ensures consistent error handling and messaging across commands. [[1]](diffhunk://#diff-4df83747d68eb52a9a47a5ab649ca8a3e17ebe40b2a42e0beacab173326b62cbR6) [[2]](diffhunk://#diff-4df83747d68eb52a9a47a5ab649ca8a3e17ebe40b2a42e0beacab173326b62cbL82-R90) [[3]](diffhunk://#diff-60bac939024ace22362349fa6ed802e16e34d8f5d282a06d2dbcc0db9b4fd220R6) [[4]](diffhunk://#diff-60bac939024ace22362349fa6ed802e16e34d8f5d282a06d2dbcc0db9b4fd220L74-R82) [[5]](diffhunk://#diff-75a4471881e802422e1badc13324499e0611986bbef7d7af32f9ce67b56c1832R7) [[6]](diffhunk://#diff-75a4471881e802422e1badc13324499e0611986bbef7d7af32f9ce67b56c1832L91-R100) [[7]](diffhunk://#diff-e793ceb232cd4b22f867724ce8225f55b8ce4bbc253c701a5ee74a97b8c034d9R6) [[8]](diffhunk://#diff-e793ceb232cd4b22f867724ce8225f55b8ce4bbc253c701a5ee74a97b8c034d9L83-R92) [[9]](diffhunk://#diff-5d266e313e87575dd8eb434a0fc471a71f2b5d5e123c8dd0201b9ea78349e92bR6) [[10]](diffhunk://#diff-5d266e313e87575dd8eb434a0fc471a71f2b5d5e123c8dd0201b9ea78349e92bL86-R95) [[11]](diffhunk://#diff-924304d647201d9f7d35039c515ff7e59e33c3668eaad0d8e02408cd387c92d4R7) [[12]](diffhunk://#diff-924304d647201d9f7d35039c515ff7e59e33c3668eaad0d8e02408cd387c92d4L84-R87) [[13]](diffhunk://#diff-924304d647201d9f7d35039c515ff7e59e33c3668eaad0d8e02408cd387c92d4R96-R97) [[14]](diffhunk://#diff-faa7c946c043b6d74fc0452c56c6192d42250e6ff64803003a633d87de611615R7) [[15]](diffhunk://#diff-faa7c946c043b6d74fc0452c56c6192d42250e6ff64803003a633d87de611615L83-R86) [[16]](diffhunk://#diff-faa7c946c043b6d74fc0452c56c6192d42250e6ff64803003a633d87de611615R99-R100) [[17]](diffhunk://#diff-431ab460732d6d96df28d324490b0e6d03285ebdb497bfb073515c38156b9169R7) [[18]](diffhunk://#diff-431ab460732d6d96df28d324490b0e6d03285ebdb497bfb073515c38156b9169L91-R100) [[19]](diffhunk://#diff-2bf6697e748d1ed7e2f73141497bf4008b24c12f55f7edbc732fe98b5be91518R6) [[20]](diffhunk://#diff-2bf6697e748d1ed7e2f73141497bf4008b24c12f55f7edbc732fe98b5be91518L90-R98) [[21]](diffhunk://#diff-dde42e91e3da11f3c5ec57d138b0d06c93d4758c7e1efbeb060db40799b4bdfaR7) [[22]](diffhunk://#diff-dde42e91e3da11f3c5ec57d138b0d06c93d4758c7e1efbeb060db40799b4bdfaL72-R81) [[23]](diffhunk://#diff-7cb5073ab7e44e5a80ef4406122a1d4c65109e6053c86461ea4dec175f0ef2a3R6) [[24]](diffhunk://#diff-7cb5073ab7e44e5a80ef4406122a1d4c65109e6053c86461ea4dec175f0ef2a3L77-R85) [[25]](diffhunk://#diff-2d9f4f80101e40dc8e7a6e780654d01823b0aeb94aad3315c965e1868e3113daR6) [[26]](diffhunk://#diff-2d9f4f80101e40dc8e7a6e780654d01823b0aeb94aad3315c965e1868e3113daL87-R95) [[27]](diffhunk://#diff-fa27a941dd30b1a146c18a57298f60cb89dc1c660a75bf476308d16df2cafb56R7) [[28]](diffhunk://#diff-fa27a941dd30b1a146c18a57298f60cb89dc1c660a75bf476308d16df2cafb56L71-R80) [[29]](diffhunk://#diff-ef8a34dccd097cab2330436c0a0c45b7ba1c9e348e5f44c257b5918fdbddec0eR6) [[30]](diffhunk://#diff-ef8a34dccd097cab2330436c0a0c45b7ba1c9e348e5f44c257b5918fdbddec0eL66-R74) [[31]](diffhunk://#diff-315276ea87f74ed4759f7fe2c5b2c7fbbb1a5f9705bbfb21ee054e9c58c56039R6) [[32]](diffhunk://#diff-315276ea87f74ed4759f7fe2c5b2c7fbbb1a5f9705bbfb21ee054e9c58c56039L75-R83)

* The `handle_cli_error` function in `parser.py` now prints error messages to standard error and returns a mapped exit code: `2` for business rule violations, `3` for missing files, and `1` for unexpected errors.

**Documentation and Testing**

* The developer guide (`DEVELOPER_GUIDE.md`) has been updated to describe the CLI error handling and exit code mapping, replacing the previous placeholder.
* Minor test imports have been updated to include the `exceptions` module, supporting new error handling logic.

These changes improve the robustness and user experience of the CLI by providing clear, actionable error messages and predictable exit codes for all command failures.