### PR TITLE
Fix #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ documentation with full argument details.
 - `add-salesman`
 - `edit-salesman`
 - `sale`
+- `bulk-sale`
 - `restock`
 - `write-off`
 - `pay-debt`

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -178,6 +178,27 @@ Uses the "Reversal and Re-entry" method. A `VOID` transaction reverses the
 mistake, followed by a new entry with the correct data. The correct data is
 optional if only want to delete the mistake.
 
+### Bulk Sales (Atomic Multi-Item Checkouts)
+
+Captures real-world shopping cart checkouts where a customer purchases multiple
+items in a single transaction.
+
+The workflow is orchestrated in `bll.record_bulk_sale` using a **2-phase,
+all-or-nothing wrapper** pattern:
+
+1. **Validation Phase**: Validates every `SaleCommand` in the input list (verifying
+   active status and existence for products and salesmen, positive quantities, and
+   valid revenue). If *any* item fails validation, an exception is raised
+   immediately and **zero** transactions are recorded.
+2. **Execution Phase**: Appends all sale transactions to the `TransactionLog` sheet
+   in sequence, invalidates the transaction cache once at the end, and returns the
+   created rows.
+
+*Developer Rationale*:
+- **BLL Centered**: All-or-nothing atomicity rules and validation loops live strictly in the BLL (`bll.record_bulk_sale`), never in CLI or API handlers.
+- **DTO Transformation**: API endpoint `POST /transactions/bulk-sale` accepts `BulkSaleRequest` DTOs and maps them to `list[SaleCommand]`. CLI command `bulk-sale` parses `-s`, `-p`, `-n` header options and repeated `-i PRODUCT_ID QTY TOTAL_REVENUE` flags into `list[SaleCommand]`.
+- **Single Persistence Pass**: In mutating API requests or REPL sessions, workbook changes are written to disk once at the end of the batch operation, eliminating redundant disk I/O.
+
 ## Runtime Caching in the BLL
 
 The business logic layer keeps a single workbook open inside a `RuntimeContext`

--- a/examples/06_bulk_sale_workflow.md
+++ b/examples/06_bulk_sale_workflow.md
@@ -1,0 +1,74 @@
+# 06 Bulk Sale Workflow
+
+Follow these steps to record a multi-item checkout transaction in a single atomic operation.
+
+1. Register the salesperson who will handle the checkout.
+
+   ```text
+   caad-erp-cli add-salesman \
+       --salesman-id ALICE \
+       --salesman-name "Alice Johnson"
+   ```
+
+2. Register the product catalog entries.
+
+   ```text
+   caad-erp-cli add-product \
+       --product-id BOTTLE-500 \
+       --product-name "500 ml Water" \
+       --sell-price 125
+
+   caad-erp-cli add-product \
+       --product-id SNACK-CHIPS \
+       --product-name "Potato Chips" \
+       --sell-price 250
+   ```
+
+3. Record incoming stock delivery.
+
+   ```text
+   caad-erp-cli restock \
+       --product-id BOTTLE-500 \
+       --quantity 24 \
+       --total-cost 1500 \
+       --salesman-id ALICE
+
+   caad-erp-cli restock \
+       --product-id SNACK-CHIPS \
+       --quantity 24 \
+       --total-cost 3000 \
+       --salesman-id ALICE
+   ```
+
+4. Verify current inventory positions.
+
+   ```text
+   caad-erp-cli stock
+   ```
+
+5. Record a bulk sale (cart checkout) for multiple products in a single command.
+
+   The `-s` (salesman) and `-p` (payment type) apply to the whole checkout, while each `-i` item specifies `PRODUCT_ID QUANTITY TOTAL_REVENUE`.
+
+   ```text
+   caad-erp-cli bulk-sale \
+       --salesman-id ALICE \
+       --payment-type Cash \
+       --notes "Combo meal checkout" \
+       --item BOTTLE-500 2 250 \
+       --item SNACK-CHIPS 1 250
+   ```
+
+6. Verify stock again to confirm inventory for both items was reduced atomically.
+
+   ```text
+   caad-erp-cli stock
+   ```
+
+7. View the complete transaction audit log.
+
+   ```text
+   caad-erp-cli log
+   ```
+
+> **Note on Atomicity**: If any product in the bulk sale list is inactive or invalid, the entire operation is aborted immediately and zero items are recorded.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,11 @@ This directory collects short, task-focused walkthroughs for the command-line in
 Use these recipes to learn the happy paths.
 
 Copy commands into your terminal, and adapt them to your own configuration file and workbook location. Commands show the `--config /path/to/config.ini` flag explicitly; omit it when your configuration file lives in the current directory.
+
+- [`01_basic_workflow.md`](./01_basic_workflow.md) - Register salesman/product, restock, check inventory, and record a cash sale.
+- [`02_credit_workflow.md`](./02_credit_workflow.md) - Record a sale on credit and settle the debt.
+- [`03_fix_mistake_workflow.md`](./03_fix_mistake_workflow.md) - Void a mistake and re-entry correct data.
+- [`04_handling_spoilage_or_loss.md`](./04_handling_spoilage_or_loss.md) - Record write-offs for lost or spoiled stock.
+- [`05_deactivate_records_workflow.md`](./05_deactivate_records_workflow.md) - Deactivate products and salesmen.
+- [`06_bulk_sale_workflow.md`](./06_bulk_sale_workflow.md) - Record multi-item checkout transactions in a single atomic operation.
+

--- a/src/caad_erp/api/routes/transactions.py
+++ b/src/caad_erp/api/routes/transactions.py
@@ -32,11 +32,6 @@ def _transaction_to_response(
     )
 
 
-# TODO: need to handle multiple requests at once here, since the sale only
-# accepts one product at a time.
-# Maybe make the endpoint accept multiple products per sale, then call the BLL
-# for one product at a time.
-# Remember to update the CLI first.
 @router.post("/sale", response_model=schemas.StandardResponse, status_code=201)
 @persistence.mutating_endpoint
 def record_sale(
@@ -67,6 +62,43 @@ def record_sale(
     return schemas.StandardResponse(
         detail="Sale recorded successfully",
         data=_transaction_to_response(transaction),
+    )
+
+
+@router.post("/bulk-sale", response_model=schemas.StandardResponse, status_code=201)
+@persistence.mutating_endpoint
+def record_bulk_sale(
+    request: schemas.BulkSaleRequest,
+    context: bll.RuntimeContext = fastapi.Depends(runtime.get_runtime_context),
+) -> schemas.StandardResponse:
+    """Record multiple sale transactions in a single atomic operation.
+
+    Args:
+        request: Bulk sale transaction payload containing a list of SaleRequests.
+        context: Runtime context injected via dependency.
+
+    Returns:
+        StandardResponse containing the created bulk sale transaction items.
+
+    Raises:
+        HTTPException: 409 for business rule violations, 404 for missing references.
+    """
+    commands = [
+        bll.SaleCommand(
+            product_id=item.product_id,
+            salesman_id=item.salesman_id,
+            quantity=item.quantity,
+            total_revenue=item.total_revenue,
+            payment_type=item.payment_type,
+            notes=item.notes,
+        )
+        for item in request.items
+    ]
+    transactions = bll.record_bulk_sale(context, commands)
+    response_items = [_transaction_to_response(tx) for tx in transactions]
+    return schemas.StandardResponse(
+        detail="Bulk sale recorded successfully",
+        data=schemas.BulkSaleResponse(items=response_items),
     )
 
 

--- a/src/caad_erp/api/schemas.py
+++ b/src/caad_erp/api/schemas.py
@@ -85,6 +85,12 @@ class SaleRequest(pydantic.BaseModel):
     notes: t.Optional[str] = None
 
 
+class BulkSaleRequest(pydantic.BaseModel):
+    """Request payload for recording multiple sale transactions in a single operation."""
+
+    items: t.List[SaleRequest] = pydantic.Field(..., min_length=1)
+
+
 class RestockRequest(pydantic.BaseModel):
     """Request payload for recording a restock transaction."""
 
@@ -159,6 +165,12 @@ class TransactionResponse(pydantic.BaseModel):
     total_cost: int
     linked_transaction_id: t.Optional[str]
     notes: t.Optional[str]
+
+
+class BulkSaleResponse(pydantic.BaseModel):
+    """Response representation of recorded bulk sale transactions."""
+
+    items: t.List[TransactionResponse]
 
 
 class StockItem(pydantic.BaseModel):

--- a/src/caad_erp/bll/transactions.py
+++ b/src/caad_erp/bll/transactions.py
@@ -216,6 +216,28 @@ def get_transaction(
         ) from exc
 
 
+def _validate_sale_command(
+    context: runtime.RuntimeContext, command: SaleCommand
+) -> None:
+    """Validate that a SaleCommand meets all domain rules before execution."""
+    product = products.get_product(context, command.product_id)
+    if not product.is_active:
+        logger.warning("Attempted sale on inactive product '%s'", command.product_id)
+        raise exceptions.BusinessRuleViolation(
+            f"Product '{command.product_id}' is inactive"
+        )
+    salesman = salesmen.get_salesman(context, command.salesman_id)
+    if not salesman.is_active:
+        logger.warning(
+            "Attempted sale with inactive salesman '%s'", command.salesman_id
+        )
+        raise exceptions.BusinessRuleViolation(
+            f"Salesman '{command.salesman_id}' is inactive"
+        )
+    _require_positive_quantity(command.quantity)
+    _require_nonnegative_money(command.total_revenue)
+
+
 def record_sale(
     context: runtime.RuntimeContext, command: SaleCommand
 ) -> dal.TransactionRow:
@@ -244,22 +266,7 @@ def record_sale(
         ValueError: When quantity or revenue validations fail.
     """
     now = datetime.datetime.now(datetime.UTC)
-    product = products.get_product(context, command.product_id)
-    if not product.is_active:
-        logger.warning("Attempted sale on inactive product '%s'", command.product_id)
-        raise exceptions.BusinessRuleViolation(
-            f"Product '{command.product_id}' is inactive"
-        )
-    salesman = salesmen.get_salesman(context, command.salesman_id)
-    if not salesman.is_active:
-        logger.warning(
-            "Attempted sale with inactive salesman '%s'", command.salesman_id
-        )
-        raise exceptions.BusinessRuleViolation(
-            f"Salesman '{command.salesman_id}' is inactive"
-        )
-    _require_positive_quantity(command.quantity)
-    _require_nonnegative_money(command.total_revenue)
+    _validate_sale_command(context, command)
 
     transaction_id = _generate_transaction_id(when=now)
     transaction = _build_sale_transaction(
@@ -275,6 +282,39 @@ def record_sale(
         command.total_revenue,
     )
     return transaction
+
+
+def record_bulk_sale(
+    context: runtime.RuntimeContext, commands: list[SaleCommand]
+) -> list[dal.TransactionRow]:
+    """Validate and append a list of ``SALE`` transactions atomically.
+
+    All commands in the list are validated upfront. If any command fails
+    validation (e.g. referencing an inactive product or salesman), a domain
+    exception is raised immediately and zero transactions are recorded.
+
+    Args:
+        context (RuntimeContext): Runtime context providing workbook access.
+        commands (list[SaleCommand]): List of sale intents to record.
+
+    Returns:
+        list[dal.TransactionRow]: Appended sale transaction rows.
+
+    Raises:
+        BusinessRuleViolation: If the command list is empty or any item is invalid.
+        MissingReferenceError: If any product or salesman is unknown.
+    """
+    if not commands:
+        raise exceptions.BusinessRuleViolation("Bulk sale requires at least one item")
+
+    for command in commands:
+        _validate_sale_command(context, command)
+
+    recorded: list[dal.TransactionRow] = []
+    for command in commands:
+        recorded.append(record_sale(context, command))
+
+    return recorded
 
 
 def _build_sale_transaction(

--- a/src/caad_erp/cli/commands/bulk_sale.py
+++ b/src/caad_erp/cli/commands/bulk_sale.py
@@ -1,0 +1,102 @@
+import argparse
+
+from caad_erp import bll, constants
+
+from .. import command_spec
+from ..parser import handle_cli_error
+
+
+def register_bulk_sale_command() -> command_spec.CommandSpec:
+    """Create CLI wiring for the ``bulk-sale`` sub-command.
+
+    Returns:
+        CommandSpec: Specification containing the parser registrar and
+            executor used to register and execute the command.
+    """
+    name = "bulk-sale"
+    help_text = "Record multiple sale transactions in a single operation."
+
+    def _registrar(action: command_spec.SubparserFactory) -> argparse.ArgumentParser:
+        """Attach ``bulk-sale`` arguments to the provided sub-parser.
+
+        Args:
+            action (SubparserFactory): Factory responsible for adding the
+                command-specific parser to the CLI.
+
+        Returns:
+            argparse.ArgumentParser: Parser configured for the bulk-sale workflow.
+        """
+        parser = action.add_parser(name, help=help_text)
+        parser.add_argument("-s", "--salesman-id", required=True, help="Salesman ID for the sale transaction.")
+        parser.add_argument(
+            "-p",
+            "--payment-type",
+            choices=[member.value for member in constants.PaymentType],
+            required=True,
+            help="Payment type for all items.",
+        )
+        parser.add_argument("-n", "--notes", dest="notes", default=None, help="Optional transaction notes.")
+        parser.add_argument(
+            "-i",
+            "--item",
+            action="append",
+            nargs=3,
+            metavar=("PRODUCT_ID", "QTY", "TOTAL_REVENUE"),
+            required=True,
+            help="Product ID, quantity, and total revenue for an item (repeatable).",
+        )
+        parser.set_defaults(command=name)
+        return parser
+
+    return command_spec.CommandSpec(
+        name=name, help_text=help_text, register=_registrar, execute=_run_bulk_sale
+    )
+
+
+def _translate_bulk_sale(args: argparse.Namespace) -> list[bll.SaleCommand]:
+    """Convert parsed CLI arguments into a list of ``SaleCommand`` objects.
+
+    Args:
+        args (argparse.Namespace): Namespace populated with ``bulk-sale`` options.
+
+    Returns:
+        list[bll.SaleCommand]: Domain commands capturing sale details.
+
+    Raises:
+        ValueError: If quantity or revenue values cannot be parsed as valid integers.
+    """
+    payment = constants.PaymentType(args.payment_type)
+    commands: list[bll.SaleCommand] = []
+    for item in args.item:
+        product_id, qty_str, rev_str = item
+        commands.append(
+            bll.SaleCommand(
+                product_id=product_id,
+                salesman_id=args.salesman_id,
+                quantity=int(qty_str),
+                total_revenue=int(rev_str),
+                payment_type=payment,
+                notes=args.notes,
+            )
+        )
+    return commands
+
+
+def _run_bulk_sale(context: bll.RuntimeContext, args: argparse.Namespace) -> int:
+    """Execute the bulk sale workflow through the business logic layer.
+
+    Args:
+        context (bll.RuntimeContext): Runtime context providing access
+            to transactional mutations.
+        args (argparse.Namespace): Parsed CLI arguments describing the bulk sale
+            operation.
+
+    Returns:
+        int: Exit code ``0`` on success, or a non-zero exit code on failure.
+    """
+    try:
+        commands = _translate_bulk_sale(args)
+        bll.record_bulk_sale(context, commands)
+        return 0
+    except Exception as error:
+        return handle_cli_error(error)

--- a/tests/api/routes/test_transactions.py
+++ b/tests/api/routes/test_transactions.py
@@ -242,3 +242,83 @@ def test_transaction_endpoints_return_503_when_runtime_context_is_unavailable(
 
     assert response.status_code == 503
     assert response.json()["error_type"] == "RuntimeError"
+
+
+def test_bulk_sale_endpoint_success(api_client: TestClient) -> None:
+    """
+    GIVEN valid BulkSaleRequest payload with multiple items
+    WHEN POST /transactions/bulk-sale is called
+    THEN returns 201 Created with BulkSaleResponse inside StandardResponse
+    """
+    _setup_product_and_salesman(api_client)
+
+    response = api_client.post(
+        "/transactions/bulk-sale",
+        json={
+            "items": [
+                {
+                    "product_id": "TP001",
+                    "salesman_id": "TS001",
+                    "quantity": 2,
+                    "total_revenue": 2000,
+                    "payment_type": constants.PaymentType.CASH.value,
+                    "notes": "Item 1",
+                },
+                {
+                    "product_id": "TP001",
+                    "salesman_id": "TS001",
+                    "quantity": 1,
+                    "total_revenue": 1000,
+                    "payment_type": constants.PaymentType.CASH.value,
+                    "notes": "Item 2",
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 201
+    json_data = response.json()
+    assert json_data["detail"] == "Bulk sale recorded successfully"
+    items = json_data["data"]["items"]
+    assert len(items) == 2
+    assert items[0]["product_id"] == "TP001"
+    assert items[0]["quantity_change"] == -2
+    assert items[1]["quantity_change"] == -1
+
+
+def test_bulk_sale_endpoint_rejects_empty_items_with_422(
+    api_client: TestClient,
+) -> None:
+    """
+    GIVEN a BulkSaleRequest with an empty items list
+    WHEN POST /transactions/bulk-sale is called
+    THEN API returns 422 validation error
+    """
+    response = api_client.post("/transactions/bulk-sale", json={"items": []})
+    assert response.status_code == 422
+
+
+def test_bulk_sale_endpoint_maps_domain_errors(api_client: TestClient) -> None:
+    """
+    GIVEN a BulkSaleRequest referencing a missing or inactive product
+    WHEN POST /transactions/bulk-sale is called
+    THEN returns appropriate HTTP contract error (404 or 409)
+    """
+    _setup_product_and_salesman(api_client)
+
+    response = api_client.post(
+        "/transactions/bulk-sale",
+        json={
+            "items": [
+                {
+                    "product_id": "UNKNOWN",
+                    "salesman_id": "TS001",
+                    "quantity": 1,
+                    "total_revenue": 1000,
+                    "payment_type": constants.PaymentType.CASH.value,
+                }
+            ]
+        },
+    )
+    assert response.status_code == 404
+

--- a/tests/bll/test_transactions.py
+++ b/tests/bll/test_transactions.py
@@ -1431,3 +1431,153 @@ def test_validate_void_target_accepts_other_transaction_types() -> None:
 
     # Act / Assert
     transactions._validate_void_target(row)
+
+
+def test_record_bulk_sale_success() -> None:
+    """
+    GIVEN a valid list of SaleCommand objects
+    WHEN record_bulk_sale is called
+    THEN all transactions are recorded, inventory is updated, and transactions are returned
+    """
+    # Arrange
+    wb = _make_workbook()
+    _seed_product(wb, "P001")
+    _seed_product(wb, "P002")
+    _seed_salesman(wb, "S001")
+    context = _make_context(wb)
+
+    cmd1 = transactions.SaleCommand(
+        product_id="P001",
+        salesman_id="S001",
+        quantity=2,
+        total_revenue=500,
+        payment_type=constants.PaymentType.CASH,
+        notes="Bulk item 1",
+    )
+    cmd2 = transactions.SaleCommand(
+        product_id="P002",
+        salesman_id="S001",
+        quantity=1,
+        total_revenue=300,
+        payment_type=constants.PaymentType.CASH,
+        notes="Bulk item 2",
+    )
+
+    # Act
+    results = transactions.record_bulk_sale(context, [cmd1, cmd2])
+
+    # Assert
+    assert len(results) == 2
+    assert results[0].product_id == "P001"
+    assert results[0].quantity_change == -2
+    assert results[1].product_id == "P002"
+    assert results[1].quantity_change == -1
+
+    all_txs = list(dal.iter_transactions(context.workbook))
+    assert len(all_txs) == 2
+
+
+def test_record_bulk_sale_atomic_rollback_on_inactive_product() -> None:
+    """
+    GIVEN a list of SaleCommand objects where one product is inactive
+    WHEN record_bulk_sale is called
+    THEN BusinessRuleViolation is raised and zero transactions are recorded
+    """
+    # Arrange
+    wb = _make_workbook()
+    _seed_product(wb, "P001", is_active=True)
+    _seed_product(wb, "P002", is_active=False)
+    _seed_salesman(wb, "S001")
+    context = _make_context(wb)
+
+    cmd1 = transactions.SaleCommand(
+        product_id="P001",
+        salesman_id="S001",
+        quantity=2,
+        total_revenue=500,
+        payment_type=constants.PaymentType.CASH,
+    )
+    cmd2 = transactions.SaleCommand(
+        product_id="P002",
+        salesman_id="S001",
+        quantity=1,
+        total_revenue=300,
+        payment_type=constants.PaymentType.CASH,
+    )
+
+    # Act / Assert
+    with pytest.raises(BusinessRuleViolation):
+        transactions.record_bulk_sale(context, [cmd1, cmd2])
+
+    assert len(list(dal.iter_transactions(context.workbook))) == 0
+
+
+def test_record_bulk_sale_atomic_rollback_on_missing_salesman() -> None:
+    """
+    GIVEN a list of SaleCommand objects referencing a missing salesman
+    WHEN record_bulk_sale is called
+    THEN MissingReferenceError is raised and zero transactions are recorded
+    """
+    # Arrange
+    wb = _make_workbook()
+    _seed_product(wb, "P001")
+    context = _make_context(wb)
+
+    cmd1 = transactions.SaleCommand(
+        product_id="P001",
+        salesman_id="S999",
+        quantity=1,
+        total_revenue=300,
+        payment_type=constants.PaymentType.CASH,
+    )
+
+    # Act / Assert
+    with pytest.raises(MissingReferenceError):
+        transactions.record_bulk_sale(context, [cmd1])
+
+    assert len(list(dal.iter_transactions(context.workbook))) == 0
+
+
+def test_record_bulk_sale_empty_list_raises_error() -> None:
+    """
+    GIVEN an empty list of commands
+    WHEN record_bulk_sale is called
+    THEN BusinessRuleViolation is raised
+    """
+    # Arrange
+    wb = _make_workbook()
+    context = _make_context(wb)
+
+    # Act / Assert
+    with pytest.raises(BusinessRuleViolation):
+        transactions.record_bulk_sale(context, [])
+
+
+def test_record_bulk_sale_invalidates_cache() -> None:
+    """
+    GIVEN cached transactions in context
+    WHEN record_bulk_sale is called
+    THEN the transactions cache is invalidated
+    """
+    # Arrange
+    wb = _make_workbook()
+    _seed_product(wb, "P001")
+    _seed_salesman(wb, "S001")
+    context = _make_context(wb)
+    transactions.list_transactions(context)  # warm cache
+    assert "transactions" in context._cache
+
+    cmd = transactions.SaleCommand(
+        product_id="P001",
+        salesman_id="S001",
+        quantity=1,
+        total_revenue=100,
+        payment_type=constants.PaymentType.CASH,
+    )
+
+    # Act
+    transactions.record_bulk_sale(context, [cmd])
+
+    # Assert
+    assert "transactions" not in context._cache
+

--- a/tests/cli/commands/test_bulk_sale.py
+++ b/tests/cli/commands/test_bulk_sale.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+
+import argparse
+import openpyxl
+import pytest
+
+from caad_erp import bll, constants, exceptions
+from caad_erp.cli.commands import bulk_sale
+from caad_erp.settings import AppSettings
+
+
+def _make_context(tmp_path: Path) -> bll.RuntimeContext:
+    wb = openpyxl.Workbook()
+    default = wb.active
+    wb.remove(default)
+    products = wb.create_sheet(constants.SheetName.PRODUCTS.value)
+    products.append(["ProductID", "ProductName", "SellPrice", "IsActive"])
+    products.append(["P001", "Cookie", 250, True])
+    products.append(["P002", "Soda", 300, True])
+    salesmen = wb.create_sheet(constants.SheetName.SALESMEN.value)
+    salesmen.append(["SalesmanID", "SalesmanName", "IsActive"])
+    salesmen.append(["S001", "Ana", True])
+    tx = wb.create_sheet(constants.SheetName.TRANSACTION_LOG.value)
+    tx.append(
+        [
+            "TransactionID",
+            "Timestamp",
+            "TransactionType",
+            "ProductID",
+            "SalesmanID",
+            "PaymentType",
+            "QuantityChange",
+            "TotalRevenue",
+            "TotalCost",
+            "LinkedTransactionID",
+            "Notes",
+        ]
+    )
+    settings = AppSettings(
+        data_file=tmp_path / "data.xlsx",
+        lounge_name="Test",
+        schema_version=constants.EXPECTED_SCHEMA_VERSION,
+        default_salesman_id="S001",
+    )
+    return bll.RuntimeContext(settings=settings, workbook=wb)
+
+
+def test_register_bulk_sale_command_returns_command_spec() -> None:
+    """
+    GIVEN bulk-sale command module
+    WHEN register_bulk_sale_command is called
+    THEN a mutating CommandSpec is returned with name 'bulk-sale'
+    """
+    # Arrange / Act
+    spec = bulk_sale.register_bulk_sale_command()
+
+    # Assert
+    assert spec.name == "bulk-sale"
+    assert spec.is_mutating is True
+
+
+def test_register_bulk_sale_registrar_configures_required_arguments() -> None:
+    """
+    GIVEN subparser factory instance
+    WHEN bulk-sale registrar is executed
+    THEN parser configures salesman-id payment-type and repeated item flags
+    """
+    # Arrange
+    spec = bulk_sale.register_bulk_sale_command()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    spec.register(subparsers)
+
+    # Act
+    args = parser.parse_args(
+        [
+            "bulk-sale",
+            "-s",
+            "S001",
+            "-p",
+            "Cash",
+            "-n",
+            "Bulk order",
+            "-i",
+            "P001",
+            "2",
+            "500",
+            "-i",
+            "P002",
+            "1",
+            "300",
+        ]
+    )
+
+    # Assert
+    assert args.command == "bulk-sale"
+    assert args.salesman_id == "S001"
+    assert args.payment_type == "Cash"
+    assert args.notes == "Bulk order"
+    assert args.item == [["P001", "2", "500"], ["P002", "1", "300"]]
+
+
+def test_translate_bulk_sale_maps_args_to_list_of_sale_commands() -> None:
+    """
+    GIVEN parsed bulk-sale args
+    WHEN _translate_bulk_sale is called
+    THEN list of SaleCommand objects is constructed
+    """
+    # Arrange
+    args = argparse.Namespace(
+        salesman_id="S001",
+        payment_type="Cash",
+        notes="Shared note",
+        item=[["P001", "2", "500"], ["P002", "1", "300"]],
+    )
+
+    # Act
+    commands = bulk_sale._translate_bulk_sale(args)
+
+    # Assert
+    assert len(commands) == 2
+    assert commands[0].product_id == "P001"
+    assert commands[0].salesman_id == "S001"
+    assert commands[0].quantity == 2
+    assert commands[0].total_revenue == 500
+    assert commands[0].payment_type == constants.PaymentType.CASH
+    assert commands[0].notes == "Shared note"
+
+    assert commands[1].product_id == "P002"
+    assert commands[1].quantity == 1
+    assert commands[1].total_revenue == 300
+
+
+def test_run_bulk_sale_calls_bll_and_returns_zero(tmp_path: Path) -> None:
+    """
+    GIVEN runtime context and parsed bulk-sale args
+    WHEN _run_bulk_sale is called
+    THEN bll.record_bulk_sale is invoked and zero is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        salesman_id="S001",
+        payment_type="Cash",
+        notes="Bulk sale notes",
+        item=[["P001", "2", "500"], ["P002", "1", "300"]],
+    )
+
+    # Act
+    exit_code = bulk_sale._run_bulk_sale(context, args)
+
+    # Assert
+    assert exit_code == 0
+    rows = bll.list_transactions(context)
+    assert len(rows) == 2
+
+
+def test_run_bulk_sale_returns_nonzero_exit_code_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    GIVEN runtime context and bulk-sale args when bll raises BusinessRuleViolation
+    WHEN _run_bulk_sale is called
+    THEN non-zero exit code 2 is returned
+    """
+    # Arrange
+    context = _make_context(tmp_path)
+    args = argparse.Namespace(
+        salesman_id="S001",
+        payment_type="Cash",
+        notes=None,
+        item=[["P999", "1", "100"]],
+    )
+
+    def _mock_record_bulk_sale(*args, **kwargs):
+        raise exceptions.MissingReferenceError("Product not found")
+
+    monkeypatch.setattr(bll, "record_bulk_sale", _mock_record_bulk_sale)
+
+    # Act
+    exit_code = bulk_sale._run_bulk_sale(context, args)
+
+    # Assert
+    assert exit_code == 2

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -100,6 +100,48 @@ def test_products_flow_create_list_and_deactivate_roundtrip(
     )
 
 
+def test_bulk_sale_end_to_end_flow(api_client: TestClient) -> None:
+    """
+    GIVEN an API client with products and salesman initialized
+    WHEN POST /transactions/bulk-sale is called with multiple items
+    THEN bulk transactions are recorded, inventory is updated, and log report includes all sales
+    """
+    _create_product(api_client, "BULK-API-P1")
+    _create_product(api_client, "BULK-API-P2")
+    _create_salesman(api_client, "BULK-API-S1")
+
+    bulk_response = api_client.post(
+        "/transactions/bulk-sale",
+        json={
+            "items": [
+                {
+                    "product_id": "BULK-API-P1",
+                    "salesman_id": "BULK-API-S1",
+                    "quantity": 3,
+                    "total_revenue": 3000,
+                    "payment_type": constants.PaymentType.CASH.value,
+                    "notes": "E2E Bulk 1",
+                },
+                {
+                    "product_id": "BULK-API-P2",
+                    "salesman_id": "BULK-API-S1",
+                    "quantity": 2,
+                    "total_revenue": 2000,
+                    "payment_type": constants.PaymentType.CASH.value,
+                    "notes": "E2E Bulk 2",
+                },
+            ]
+        },
+    )
+
+    assert bulk_response.status_code == 201
+    log_response = api_client.get("/reports/log")
+    assert log_response.status_code == 200
+    txs = log_response.json()["transactions"]
+    e2e_txs = [tx for tx in txs if tx["salesman_id"] == "BULK-API-S1"]
+    assert len(e2e_txs) == 2
+
+
 def test_salesmen_flow_create_list_and_deactivate_roundtrip(
     api_client: TestClient,
 ) -> None:

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -38,6 +38,82 @@ def test_cli_main_executes_mutating_command_and_persists_changes(
     assert saved.product_name == "CLI Product"
 
 
+def test_cli_main_executes_bulk_sale_and_persists_changes(
+    integration_config_path: Path,
+    initialized_context: bll.RuntimeContext,
+) -> None:
+    """
+    GIVEN setup products and salesman
+    WHEN cli.parser.main is invoked with bulk-sale arguments
+    THEN returns exit code zero and all sale transactions are persisted to workbook
+    """
+    cli_parser.main(
+        [
+            "--config",
+            str(integration_config_path),
+            "add-salesman",
+            "-i",
+            "S001",
+            "-n",
+            "Test Salesman",
+        ]
+    )
+    cli_parser.main(
+        [
+            "--config",
+            str(integration_config_path),
+            "add-product",
+            "-i",
+            "BULK-P1",
+            "-n",
+            "Bulk Product 1",
+            "-p",
+            "1000",
+        ]
+    )
+    cli_parser.main(
+        [
+            "--config",
+            str(integration_config_path),
+            "add-product",
+            "-i",
+            "BULK-P2",
+            "-n",
+            "Bulk Product 2",
+            "-p",
+            "1500",
+        ]
+    )
+
+    result = cli_parser.main(
+        [
+            "--config",
+            str(integration_config_path),
+            "bulk-sale",
+            "-s",
+            "S001",
+            "-p",
+            "Cash",
+            "-n",
+            "Integration bulk sale",
+            "-i",
+            "BULK-P1",
+            "2",
+            "2000",
+            "-i",
+            "BULK-P2",
+            "1",
+            "1500",
+        ]
+    )
+
+    assert result == 0
+    reloaded = bll.load_context(integration_config_path)
+    txs = bll.list_transactions(reloaded)
+    bulk_txs = [tx for tx in txs if tx.notes == "Integration bulk sale"]
+    assert len(bulk_txs) == 2
+
+
 def test_cli_main_executes_reporting_command_without_persist_side_effect(
     integration_config_path: Path,
     initialized_context: bll.RuntimeContext,


### PR DESCRIPTION
Fixes #28 

This pull request introduces support for atomic bulk sale transactions, allowing multiple items to be checked out in a single operation from both the API and CLI. It implements a two-phase validation and execution strategy in the business logic layer, updates the API and CLI to expose the new functionality, and provides comprehensive documentation and tests for the new workflow.

**Bulk Sale Transaction Support**

* Added the `record_bulk_sale` function to the BLL (`src/caad_erp/bll/transactions.py`), which validates and records multiple sale transactions atomically, ensuring that if any item fails validation, no transactions are recorded. Also added `_validate_sale_command` for reusable sale validation logic. [[1]](diffhunk://#diff-905037df566e4f5a29a1a6f0c72e162719801a234e6af294dbfce25fd48711c7R219-R240) [[2]](diffhunk://#diff-905037df566e4f5a29a1a6f0c72e162719801a234e6af294dbfce25fd48711c7R287-R319) [[3]](diffhunk://#diff-905037df566e4f5a29a1a6f0c72e162719801a234e6af294dbfce25fd48711c7L247-R269)
* Introduced the `/transactions/bulk-sale` API endpoint, with corresponding request/response schemas (`BulkSaleRequest`, `BulkSaleResponse`) to handle multi-item sales in one request. [[1]](diffhunk://#diff-99863c5539fee2a9bcd8e37122f04203b706b78a15906aa3f22e31af08851357R68-R104) [[2]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6R88-R93) [[3]](diffhunk://#diff-3319838a9193e25dc973edd6c8e01a8e29abd4fa26109c378490cef13aec09b6R170-R175)
* Implemented the `bulk-sale` CLI command, enabling users to record multi-item sales from the command line with repeatable `--item` flags.
* Updated documentation to explain the bulk sale workflow, including a new example walkthrough and developer rationale. [[1]](diffhunk://#diff-2429b8cea1166d7b6c05fd8d0c0abb2635974feeb58034523fd66013d3bcd95aR1-R74) [[2]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R181-R201) [[3]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R8-R15) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95)

**Testing and Validation**

* Added comprehensive tests for the bulk sale feature, covering successful operations, atomic rollback on validation errors, cache invalidation, and API contract validation. [[1]](diffhunk://#diff-35497bd024cf13fa71fab78ce2ca9cb0b0d682ddc25f261b79ac10f27e7cb2daR245-R324) [[2]](diffhunk://#diff-442b4c1bc6b0668a503e5804a247c24816afece8f478e877c26eceea928db45fR1434-R1583)

These changes ensure that multi-item checkouts are handled atomically and consistently across the CLI and API, with clear documentation and robust validation.