### PR TITLE
Update frontend rules to follow backend rules

### DIFF
--- a/frontend/src/features/products/components/ProductFormModal.tsx
+++ b/frontend/src/features/products/components/ProductFormModal.tsx
@@ -44,7 +44,7 @@ export function ProductFormModal({
             product_id: (value) =>
                 isEditing || value.trim().length > 0 ? null : "Informe um identificador",
             product_name: (value) => (value.trim().length > 0 ? null : "Informe um nome"),
-            sell_price: (value) => (value > 0 ? null : "Informe um preço válido"),
+            sell_price: (value) => (value >= 0 ? null : "Informe um preço válido"),
         },
     })
 

--- a/frontend/src/features/stock/components/RestockModal.tsx
+++ b/frontend/src/features/stock/components/RestockModal.tsx
@@ -45,9 +45,9 @@ export function RestockModal({
         validate: {
             quantity: (value) => (value > 0 ? null : "Informe uma quantidade válida"),
             unit_cost: (value, values) =>
-                values.cost_mode === "unit" && value <= 0 ? "Informe um custo válido" : null,
+                values.cost_mode === "unit" && value < 0 ? "Informe um custo válido" : null,
             total_cost: (value, values) =>
-                values.cost_mode === "total" && value <= 0 ? "Informe um custo válido" : null,
+                values.cost_mode === "total" && value < 0 ? "Informe um custo válido" : null,
         },
     })
 


### PR DESCRIPTION
Fixes #91 

This pull request updates input validation logic in the product and stock management modals to allow zero values where appropriate and to enforce stricter validation in other cases.

**Validation logic updates:**

* In `ProductFormModal.tsx`, the `sell_price` field now accepts zero as a valid value (previously only values greater than zero were allowed).
* In `RestockModal.tsx`, the validation for `unit_cost` and `total_cost` fields now only disallows negative values (previously zero was also disallowed), so zero is now accepted as valid input.