### PR TITLE
Stock enforcement, multiple credit payments, credit payment voiding

### DIFF
--- a/backend/src/caad_erp/bll/reports.py
+++ b/backend/src/caad_erp/bll/reports.py
@@ -118,20 +118,22 @@ def calculate_outstanding_debts(context: runtime.RuntimeContext) -> dict[str, t.
 
     all_transactions = transactions.list_transactions(context)
 
+    voided_tx_ids = {
+        entry.linked_transaction_id
+        for entry in all_transactions
+        if entry.transaction_type == constants.TransactionType.VOID.value
+        and entry.linked_transaction_id
+    }
+
     payments_by_sale: dict[str, int] = collections.defaultdict(int)
-    voided_sales: set[str] = set()
 
     for entry in all_transactions:
         if (
             entry.transaction_type == constants.TransactionType.CREDIT_PAYMENT.value
             and entry.linked_transaction_id
+            and entry.transaction_id not in voided_tx_ids
         ):
             payments_by_sale[entry.linked_transaction_id] += entry.total_revenue
-        elif (
-            entry.transaction_type == constants.TransactionType.VOID.value
-            and entry.linked_transaction_id
-        ):
-            voided_sales.add(entry.linked_transaction_id)
 
     balances: list[OutstandingDebt] = []
     total_balance = 0
@@ -141,7 +143,7 @@ def calculate_outstanding_debts(context: runtime.RuntimeContext) -> dict[str, t.
             continue
         if entry.payment_type != constants.PaymentType.ON_CREDIT.value:
             continue
-        if entry.transaction_id in voided_sales:
+        if entry.transaction_id in voided_tx_ids:
             continue
 
         quantity = abs(entry.quantity_change)

--- a/backend/src/caad_erp/bll/transactions.py
+++ b/backend/src/caad_erp/bll/transactions.py
@@ -7,6 +7,7 @@ business rules through centralized validators, and maintain cache coherence so
 reporting modules observe consistent state.
 """
 
+import collections
 import dataclasses
 import datetime
 import logging
@@ -14,7 +15,7 @@ import typing as t
 
 from caad_erp import constants, dal, exceptions
 
-from . import products, runtime, salesmen
+from . import products, reports, runtime, salesmen
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +238,19 @@ def _validate_sale_command(
     _require_positive_quantity(command.quantity)
     _require_nonnegative_money(command.total_revenue)
 
+    inventory = reports.calculate_inventory(context)
+    available_stock = inventory.get(command.product_id, 0)
+    if command.quantity > available_stock:
+        logger.warning(
+            "Attempted sale exceeding stock for product '%s' (available=%s, requested=%s)",
+            command.product_id,
+            available_stock,
+            command.quantity,
+        )
+        raise exceptions.BusinessRuleViolation(
+            f"Insufficient stock for product '{command.product_id}': available {available_stock}, requested {command.quantity}"
+        )
+
 
 def record_sale(
     context: runtime.RuntimeContext, command: SaleCommand
@@ -309,6 +323,24 @@ def record_bulk_sale(
 
     for command in commands:
         _validate_sale_command(context, command)
+
+    inventory = reports.calculate_inventory(context)
+    aggregate_quantities: dict[str, int] = collections.defaultdict(int)
+    for command in commands:
+        aggregate_quantities[command.product_id] += command.quantity
+
+    for product_id, total_requested in aggregate_quantities.items():
+        available_stock = inventory.get(product_id, 0)
+        if total_requested > available_stock:
+            logger.warning(
+                "Bulk sale total requested exceeding stock for product '%s' (available=%s, total_requested=%s)",
+                product_id,
+                available_stock,
+                total_requested,
+            )
+            raise exceptions.BusinessRuleViolation(
+                f"Insufficient stock for product '{product_id}': available {available_stock}, total requested in cart {total_requested}"
+            )
 
     recorded: list[dal.TransactionRow] = []
     for command in commands:
@@ -462,7 +494,7 @@ def record_write_off(
         dal.TransactionRow: Newly appended write-off entry.
 
     Raises:
-        BusinessRuleViolation: If the product is inactive.
+        BusinessRuleViolation: If the product is inactive or quantity exceeds stock.
         MissingReferenceError: When the referenced product id is unknown.
         ValueError: If the quantity fails validation.
     """
@@ -484,6 +516,19 @@ def record_write_off(
             f"Salesman '{command.salesman_id}' is inactive"
         )
     _require_positive_quantity(command.quantity)
+
+    inventory = reports.calculate_inventory(context)
+    available_stock = inventory.get(command.product_id, 0)
+    if command.quantity > available_stock:
+        logger.warning(
+            "Attempted write-off exceeding stock for product '%s' (available=%s, requested=%s)",
+            command.product_id,
+            available_stock,
+            command.quantity,
+        )
+        raise exceptions.BusinessRuleViolation(
+            f"Cannot write off {command.quantity} units of product '{command.product_id}': only {available_stock} available"
+        )
 
     transaction_id = _generate_transaction_id(when=now)
     transaction = _build_write_off_transaction(
@@ -556,12 +601,17 @@ def record_credit_payment(
             credit payment linkage.
         MissingReferenceError: When the linked transaction identifier is
             unknown.
-        ValueError: If the payment amount is negative.
+        ValueError: If the payment amount is negative or zero.
     """
     now = datetime.datetime.now(datetime.UTC)
     linked_sale = get_transaction(context, command.linked_transaction_id)
-    _validate_credit_sale_link(linked_sale)
-    _require_nonnegative_money(command.total_revenue)
+    _validate_credit_sale_link(context, linked_sale)
+    if command.total_revenue <= 0:
+        logger.error(
+            "Credit payment validation failed: non-positive revenue '%s'",
+            command.total_revenue,
+        )
+        raise ValueError("Payment amount must be greater than zero")
     salesman = salesmen.get_salesman(context, command.salesman_id)
     if not salesman.is_active:
         logger.warning(
@@ -596,24 +646,7 @@ def _build_credit_payment_transaction(
     timestamp: datetime.datetime,
     product_id: str,
 ) -> dal.TransactionRow:
-    """Materialize a :class:`CreditPaymentCommand` into a DAL transaction row.
-
-    Args:
-        command (CreditPaymentCommand): User intent describing the credit
-            payment.
-        transaction_id (str): Unique identifier allocated for the transaction.
-        timestamp (datetime): Timestamp assigned to the transaction.
-        product_id (str): Product identifier inferred from the linked sale.
-
-    Returns:
-        dal.TransactionRow: Row ready for persistence via the data
-            layer.
-
-    Credit payments do not affect stock, so the quantity is fixed at zero. The
-    helper records the payment type supplied by the caller so downstream
-    reporting can distinguish how the credit was settled. The linked sale
-    identifier is copied for traceability.
-    """
+    """Materialize a :class:`CreditPaymentCommand` into a DAL transaction row."""
     return dal.TransactionRow(
         transaction_id=transaction_id,
         timestamp_iso=timestamp.isoformat(),
@@ -629,21 +662,19 @@ def _build_credit_payment_transaction(
     )
 
 
-def _validate_credit_sale_link(transaction: dal.TransactionRow) -> None:
+def _validate_credit_sale_link(
+    context: runtime.RuntimeContext, transaction: dal.TransactionRow
+) -> None:
     """Ensure a sale transaction qualifies for credit payment linkage.
 
     Args:
+        context (RuntimeContext): Active runtime context.
         transaction (dal.TransactionRow): Transaction row purportedly
             representing a credit sale.
 
     Raises:
         BusinessRuleViolation: If ``transaction`` is not a credit sale eligible
             for a payment linkage.
-
-    Credit payments are only allowed to target sales that were recorded on
-    credit, have not yet reported revenue, and are not already linked to another
-    transaction. These conditions prevent double-settling or misclassifying a
-    cash sale as credit.
     """
     if transaction.transaction_type != constants.TransactionType.SALE.value:
         logger.error(
@@ -660,22 +691,19 @@ def _validate_credit_sale_link(transaction: dal.TransactionRow) -> None:
             transaction.payment_type,
         )
         raise exceptions.BusinessRuleViolation("Linked sale is not recorded as credit")
-    if transaction.total_revenue > 0:
+    voided_tx_ids = {
+        tx.linked_transaction_id
+        for tx in list_transactions(context)
+        if tx.transaction_type == constants.TransactionType.VOID.value
+        and tx.linked_transaction_id
+    }
+    if transaction.transaction_id in voided_tx_ids:
         logger.error(
-            "Credit payment validation failed: transaction '%s' already reports revenue",
+            "Credit payment validation failed: sale transaction '%s' is voided",
             transaction.transaction_id,
         )
         raise exceptions.BusinessRuleViolation(
-            "Linked credit sale already reports revenue"
-        )
-    if transaction.linked_transaction_id is not None:
-        logger.error(
-            "Credit payment validation failed: transaction '%s' already links to '%s'",
-            transaction.transaction_id,
-            transaction.linked_transaction_id,
-        )
-        raise exceptions.BusinessRuleViolation(
-            "Linked sale already references another transaction"
+            "Cannot process credit payment for voided transaction"
         )
 
 
@@ -860,9 +888,8 @@ def _validate_void_target(transaction: dal.TransactionRow) -> None:
         BusinessRuleViolation: If the transaction type is ineligible for
             voiding.
 
-    VOID and CREDIT_PAYMENT transactions are intentionally immutable because a
-    second void would create loops and credit payments represent actual cash
-    settlements. Attempting to void these entries surfaces a domain error.
+    VOID transactions are intentionally immutable because a second void would
+    create loops. Attempting to void a VOID surfaces a domain error.
     """
     if transaction.transaction_type == constants.TransactionType.VOID.value:
         logger.error(
@@ -870,11 +897,3 @@ def _validate_void_target(transaction: dal.TransactionRow) -> None:
             transaction.transaction_id,
         )
         raise exceptions.BusinessRuleViolation("Cannot void a VOID transaction")
-    if transaction.transaction_type == constants.TransactionType.CREDIT_PAYMENT.value:
-        logger.error(
-            "Cannot void transaction '%s' because it is a credit payment",
-            transaction.transaction_id,
-        )
-        raise exceptions.BusinessRuleViolation(
-            "Cannot void a credit payment transaction"
-        )

--- a/backend/tests/api/routes/test_transactions.py
+++ b/backend/tests/api/routes/test_transactions.py
@@ -21,8 +21,18 @@ def _setup_product_and_salesman(client: TestClient) -> None:
             "is_active": True,
         },
     )
+    restock_response = client.post(
+        "/transactions/restock",
+        json={
+            "product_id": "TP001",
+            "salesman_id": "TS001",
+            "quantity": 100,
+            "total_cost": 50000,
+        },
+    )
     assert product_response.status_code == 201
     assert salesman_response.status_code == 201
+    assert restock_response.status_code == 201
 
 
 # happy path

--- a/backend/tests/bll/test_transactions.py
+++ b/backend/tests/bll/test_transactions.py
@@ -340,6 +340,17 @@ def test_record_sale_appends_transaction_and_invalidates_cache() -> None:
     context = _make_context(workbook)
     _seed_product(workbook, "P1", is_active=True)
     _seed_salesman(workbook, "S1", is_active=True)
+    _seed_transaction(
+        workbook,
+        "R1",
+        constants.TransactionType.RESTOCK.value,
+        "P1",
+        "S1",
+        None,
+        10,
+        0,
+        -1000,
+    )
     transactions.list_transactions(context)  # warm cache
 
     # Act
@@ -716,6 +727,17 @@ def test_record_write_off_appends_transaction_and_invalidates_cache() -> None:
     context = _make_context(workbook)
     _seed_product(workbook, "P1")
     _seed_salesman(workbook, "S1")
+    _seed_transaction(
+        workbook,
+        "R1",
+        constants.TransactionType.RESTOCK.value,
+        "P1",
+        "S1",
+        None,
+        10,
+        0,
+        -1000,
+    )
     transactions.list_transactions(context)
 
     # Act
@@ -1049,32 +1071,6 @@ def test_build_credit_payment_transaction_applies_expected_field_mapping() -> No
             linked_transaction_id=None,
             notes=None,
         ),
-        dal.TransactionRow(
-            transaction_id="X3",
-            timestamp_iso="2026-03-15T10:00:00+00:00",
-            transaction_type=constants.TransactionType.SALE.value,
-            product_id="P1",
-            salesman_id="S1",
-            payment_type=constants.PaymentType.ON_CREDIT.value,
-            quantity_change=-1,
-            total_revenue=100,
-            total_cost=0,
-            linked_transaction_id=None,
-            notes=None,
-        ),
-        dal.TransactionRow(
-            transaction_id="X4",
-            timestamp_iso="2026-03-15T10:00:00+00:00",
-            transaction_type=constants.TransactionType.SALE.value,
-            product_id="P1",
-            salesman_id="S1",
-            payment_type=constants.PaymentType.ON_CREDIT.value,
-            quantity_change=-1,
-            total_revenue=0,
-            total_cost=0,
-            linked_transaction_id="OTHER",
-            notes=None,
-        ),
     ],
 )
 def test_validate_credit_sale_link_rejects_ineligible_transactions(link_case) -> None:
@@ -1083,9 +1079,13 @@ def test_validate_credit_sale_link_rejects_ineligible_transactions(link_case) ->
     WHEN _validate_credit_sale_link is called
     THEN BusinessRuleViolation is raised
     """
-    # Arrange / Act / Assert
+    # Arrange
+    wb = _make_workbook()
+    context = _make_context(wb)
+
+    # Act / Assert
     with pytest.raises(BusinessRuleViolation):
-        transactions._validate_credit_sale_link(link_case)
+        transactions._validate_credit_sale_link(context, link_case)
 
 
 def test_validate_credit_sale_link_accepts_valid_credit_sale() -> None:
@@ -1095,6 +1095,8 @@ def test_validate_credit_sale_link_accepts_valid_credit_sale() -> None:
     THEN no exception is raised
     """
     # Arrange
+    wb = _make_workbook()
+    context = _make_context(wb)
     valid = dal.TransactionRow(
         transaction_id="SALE1",
         timestamp_iso="2026-03-15T10:00:00+00:00",
@@ -1110,7 +1112,7 @@ def test_validate_credit_sale_link_accepts_valid_credit_sale() -> None:
     )
 
     # Act / Assert
-    transactions._validate_credit_sale_link(valid)
+    transactions._validate_credit_sale_link(context, valid)
 
 
 def test_record_open_stock_appends_transaction_and_invalidates_cache() -> None:
@@ -1306,14 +1308,13 @@ def test_record_void_propagates_unknown_target_transaction() -> None:
 
 def test_record_void_rejects_ineligible_target_types() -> None:
     """
-    GIVEN a void command targeting transaction type VOID or CREDIT_PAYMENT
+    GIVEN a void command targeting transaction type VOID
     WHEN record_void is called
     THEN BusinessRuleViolation is raised
     """
     # Arrange
     for tx_type in [
         constants.TransactionType.VOID.value,
-        constants.TransactionType.CREDIT_PAYMENT.value,
     ]:
         workbook = _make_workbook()
         context = _make_context(workbook)
@@ -1378,12 +1379,11 @@ def test_build_void_transaction_negates_numeric_fields_and_links_original_id() -
     "ineligible_type",
     [
         constants.TransactionType.VOID.value,
-        constants.TransactionType.CREDIT_PAYMENT.value,
     ],
 )
 def test_validate_void_target_rejects_ineligible_types(ineligible_type) -> None:
     """
-    GIVEN a transaction whose type is VOID or CREDIT_PAYMENT
+    GIVEN a transaction whose type is VOID
     WHEN _validate_void_target is called
     THEN BusinessRuleViolation is raised
     """
@@ -1443,6 +1443,8 @@ def test_record_bulk_sale_success() -> None:
     _seed_product(wb, "P001")
     _seed_product(wb, "P002")
     _seed_salesman(wb, "S001")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P001", "S001", None, 10, 0, -1000)
+    _seed_transaction(wb, "R2", constants.TransactionType.RESTOCK.value, "P002", "S001", None, 10, 0, -1000)
     context = _make_context(wb)
 
     cmd1 = transactions.SaleCommand(
@@ -1473,7 +1475,7 @@ def test_record_bulk_sale_success() -> None:
     assert results[1].quantity_change == -1
 
     all_txs = list(dal.iter_transactions(context.workbook))
-    assert len(all_txs) == 2
+    assert len(all_txs) == 4
 
 
 def test_record_bulk_sale_atomic_rollback_on_inactive_product() -> None:
@@ -1487,6 +1489,8 @@ def test_record_bulk_sale_atomic_rollback_on_inactive_product() -> None:
     _seed_product(wb, "P001", is_active=True)
     _seed_product(wb, "P002", is_active=False)
     _seed_salesman(wb, "S001")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P001", "S001", None, 10, 0, -1000)
+    _seed_transaction(wb, "R2", constants.TransactionType.RESTOCK.value, "P002", "S001", None, 10, 0, -1000)
     context = _make_context(wb)
 
     cmd1 = transactions.SaleCommand(
@@ -1508,7 +1512,7 @@ def test_record_bulk_sale_atomic_rollback_on_inactive_product() -> None:
     with pytest.raises(BusinessRuleViolation):
         transactions.record_bulk_sale(context, [cmd1, cmd2])
 
-    assert len(list(dal.iter_transactions(context.workbook))) == 0
+    assert len(list(dal.iter_transactions(context.workbook))) == 2
 
 
 def test_record_bulk_sale_atomic_rollback_on_missing_salesman() -> None:
@@ -1562,6 +1566,7 @@ def test_record_bulk_sale_invalidates_cache() -> None:
     wb = _make_workbook()
     _seed_product(wb, "P001")
     _seed_salesman(wb, "S001")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P001", "S001", None, 10, 0, -1000)
     context = _make_context(wb)
     transactions.list_transactions(context)  # warm cache
     assert "transactions" in context._cache
@@ -1579,3 +1584,152 @@ def test_record_bulk_sale_invalidates_cache() -> None:
 
     # Assert
     assert "transactions" not in context._cache
+
+
+def test_record_sale_rejects_insufficient_stock() -> None:
+    """
+    GIVEN a sale command requesting more quantity than available stock
+    WHEN record_sale is called
+    THEN BusinessRuleViolation is raised
+    """
+    wb = _make_workbook()
+    _seed_product(wb, "P1")
+    _seed_salesman(wb, "S1")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P1", "S1", None, 3, 0, -300)
+    context = _make_context(wb)
+
+    with pytest.raises(BusinessRuleViolation) as exc_info:
+        transactions.record_sale(
+            context,
+            transactions.SaleCommand(
+                product_id="P1",
+                salesman_id="S1",
+                quantity=5,
+                total_revenue=500,
+                payment_type=constants.PaymentType.CASH,
+            ),
+        )
+    assert "Insufficient stock" in str(exc_info.value)
+
+
+def test_record_bulk_sale_rejects_insufficient_aggregate_stock() -> None:
+    """
+    GIVEN a bulk sale request where aggregate cart items exceed product stock
+    WHEN record_bulk_sale is called
+    THEN BusinessRuleViolation is raised and zero sales are recorded
+    """
+    wb = _make_workbook()
+    _seed_product(wb, "P1")
+    _seed_salesman(wb, "S1")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P1", "S1", None, 3, 0, -300)
+    context = _make_context(wb)
+
+    cmd1 = transactions.SaleCommand(product_id="P1", salesman_id="S1", quantity=2, total_revenue=200, payment_type=constants.PaymentType.CASH)
+    cmd2 = transactions.SaleCommand(product_id="P1", salesman_id="S1", quantity=2, total_revenue=200, payment_type=constants.PaymentType.CASH)
+
+    with pytest.raises(BusinessRuleViolation) as exc_info:
+        transactions.record_bulk_sale(context, [cmd1, cmd2])
+    assert "Insufficient stock" in str(exc_info.value)
+
+
+def test_record_write_off_rejects_insufficient_stock() -> None:
+    """
+    GIVEN a write-off command requesting more quantity than available stock
+    WHEN record_write_off is called
+    THEN BusinessRuleViolation is raised
+    """
+    wb = _make_workbook()
+    _seed_product(wb, "P1")
+    _seed_salesman(wb, "S1")
+    context = _make_context(wb)
+
+    with pytest.raises(BusinessRuleViolation) as exc_info:
+        transactions.record_write_off(
+            context,
+            transactions.WriteOffCommand(product_id="P1", salesman_id="S1", quantity=1),
+        )
+    assert "Cannot write off" in str(exc_info.value)
+
+
+def test_record_credit_payment_allows_multiple_and_overpayment() -> None:
+    """
+    GIVEN an active credit sale
+    WHEN multiple credit payments including overpayments are recorded
+    THEN all payment transactions succeed and record expected revenue
+    """
+    wb = _make_workbook()
+    _seed_product(wb, "P1")
+    _seed_salesman(wb, "S1")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P1", "S1", None, 5, 0, -500)
+    context = _make_context(wb)
+
+    sale = transactions.record_sale(
+        context,
+        transactions.SaleCommand(
+            product_id="P1",
+            salesman_id="S1",
+            quantity=1,
+            total_revenue=0,
+            payment_type=constants.PaymentType.ON_CREDIT,
+        ),
+    )
+
+    p1 = transactions.record_credit_payment(
+        context,
+        transactions.CreditPaymentCommand(
+            linked_transaction_id=sale.transaction_id,
+            salesman_id="S1",
+            total_revenue=500,
+            payment_type=constants.PaymentType.CASH,
+        ),
+    )
+    p2 = transactions.record_credit_payment(
+        context,
+        transactions.CreditPaymentCommand(
+            linked_transaction_id=sale.transaction_id,
+            salesman_id="S1",
+            total_revenue=600,
+            payment_type=constants.PaymentType.PIX,
+        ),
+    )
+
+    assert p1.total_revenue == 500
+    assert p2.total_revenue == 600
+
+
+def test_record_void_allows_voiding_credit_payment() -> None:
+    """
+    GIVEN a credit payment transaction
+    WHEN record_void is executed targeting the credit payment
+    THEN a VOID transaction is appended negating the payment revenue
+    """
+    wb = _make_workbook()
+    _seed_product(wb, "P1")
+    _seed_salesman(wb, "S1")
+    _seed_transaction(wb, "R1", constants.TransactionType.RESTOCK.value, "P1", "S1", None, 5, 0, -500)
+    context = _make_context(wb)
+
+    sale = transactions.record_sale(
+        context,
+        transactions.SaleCommand(
+            product_id="P1", salesman_id="S1", quantity=1, total_revenue=0, payment_type=constants.PaymentType.ON_CREDIT
+        ),
+    )
+    payment = transactions.record_credit_payment(
+        context,
+        transactions.CreditPaymentCommand(
+            linked_transaction_id=sale.transaction_id,
+            salesman_id="S1",
+            total_revenue=500,
+            payment_type=constants.PaymentType.CASH,
+        ),
+    )
+
+    void_tx = transactions.record_void(
+        context,
+        transactions.VoidCommand(linked_transaction_id=payment.transaction_id),
+    )
+
+    assert void_tx.transaction_type == constants.TransactionType.VOID.value
+    assert void_tx.linked_transaction_id == payment.transaction_id
+    assert void_tx.total_revenue == -500

--- a/backend/tests/integration/test_api_integration.py
+++ b/backend/tests/integration/test_api_integration.py
@@ -109,6 +109,24 @@ def test_bulk_sale_end_to_end_flow(api_client: TestClient) -> None:
     _create_product(api_client, "BULK-API-P1")
     _create_product(api_client, "BULK-API-P2")
     _create_salesman(api_client, "BULK-API-S1")
+    api_client.post(
+        "/transactions/restock",
+        json={
+            "product_id": "BULK-API-P1",
+            "salesman_id": "BULK-API-S1",
+            "quantity": 10,
+            "total_cost": 1000,
+        },
+    )
+    api_client.post(
+        "/transactions/restock",
+        json={
+            "product_id": "BULK-API-P2",
+            "salesman_id": "BULK-API-S1",
+            "quantity": 10,
+            "total_cost": 1000,
+        },
+    )
 
     bulk_response = api_client.post(
         "/transactions/bulk-sale",
@@ -138,7 +156,12 @@ def test_bulk_sale_end_to_end_flow(api_client: TestClient) -> None:
     log_response = api_client.get("/reports/log")
     assert log_response.status_code == 200
     txs = log_response.json()["transactions"]
-    e2e_txs = [tx for tx in txs if tx["salesman_id"] == "BULK-API-S1"]
+    e2e_txs = [
+        tx
+        for tx in txs
+        if tx["salesman_id"] == "BULK-API-S1"
+        and tx["transaction_type"] == constants.TransactionType.SALE.value
+    ]
     assert len(e2e_txs) == 2
 
 
@@ -191,6 +214,15 @@ def test_transaction_mutation_endpoints_create_transaction_records(
     """
     _create_product(api_client, "API-PTX")
     _create_salesman(api_client, "API-STX")
+    api_client.post(
+        "/transactions/restock",
+        json={
+            "product_id": "API-PTX",
+            "salesman_id": "API-STX",
+            "quantity": 100,
+            "total_cost": 10000,
+        },
+    )
 
     payload_by_endpoint = {
         "sale": {
@@ -476,6 +508,16 @@ def test_api_maps_missing_references_to_404(
         )
     elif missing_reference_case == "sale_unknown_salesman":
         _create_product(api_client, "MR-P001")
+        _create_salesman(api_client, "MR-S001")
+        api_client.post(
+            "/transactions/restock",
+            json={
+                "product_id": "MR-P001",
+                "salesman_id": "MR-S001",
+                "quantity": 10,
+                "total_cost": 1000,
+            },
+        )
         response = api_client.post(
             "/transactions/sale",
             json={
@@ -572,32 +614,26 @@ def test_api_maps_business_rule_violations_to_409(
     else:
         _create_product(api_client, "BR-P004")
         _create_salesman(api_client, "BR-S004")
-        credit_sale_response = api_client.post(
-            "/transactions/sale",
+        restock = api_client.post(
+            "/transactions/restock",
             json={
                 "product_id": "BR-P004",
                 "salesman_id": "BR-S004",
                 "quantity": 2,
-                "total_revenue": 0,
-                "payment_type": constants.PaymentType.ON_CREDIT.value,
+                "total_cost": 500,
             },
         )
-        assert credit_sale_response.status_code == 201
-        credit_sale_id = credit_sale_response.json()["data"]["transaction_id"]
-        payment_response = api_client.post(
-            "/transactions/pay-debt",
-            json={
-                "linked_transaction_id": credit_sale_id,
-                "salesman_id": "BR-S004",
-                "total_revenue": 500,
-                "payment_type": constants.PaymentType.CASH.value,
-            },
+        assert restock.status_code == 201
+        restock_id = restock.json()["data"]["transaction_id"]
+        first_void = api_client.post(
+            "/transactions/void",
+            json={"linked_transaction_id": restock_id},
         )
-        assert payment_response.status_code == 201
-        credit_payment_id = payment_response.json()["data"]["transaction_id"]
+        assert first_void.status_code == 201
+        void_id = first_void.json()["data"]["transaction_id"]
         response = api_client.post(
             "/transactions/void",
-            json={"linked_transaction_id": credit_payment_id},
+            json={"linked_transaction_id": void_id},
         )
 
     body = response.json()
@@ -751,6 +787,17 @@ def test_master_workbook_download_integration_flow(api_client: TestClient) -> No
 
     _create_product(api_client, "INT-WB-P1", sell_price=1500)
     _create_salesman(api_client, "INT-WB-S1")
+
+    restock_res = api_client.post(
+        "/transactions/restock",
+        json={
+            "product_id": "INT-WB-P1",
+            "salesman_id": "INT-WB-S1",
+            "quantity": 10,
+            "total_cost": 1000,
+        },
+    )
+    assert restock_res.status_code == 201
 
     sale_res = api_client.post(
         "/transactions/sale",

--- a/backend/tests/integration/test_business_workflows_integration.py
+++ b/backend/tests/integration/test_business_workflows_integration.py
@@ -154,6 +154,15 @@ def test_credit_sale_then_payment_reduces_outstanding_debt(
     """
     _add_product(initialized_context, "WF-P006", price=1000)
     _add_salesman(initialized_context, "WF-S006")
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="WF-P006",
+            salesman_id="WF-S006",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
     sale = bll.record_sale(
         initialized_context,
         bll.SaleCommand(
@@ -441,11 +450,20 @@ def test_invalid_void_chains_raise_without_creating_partial_rows(
 ) -> None:
     """
     GIVEN a credit-sale lifecycle with a settlement payment and a valid sale void
-    WHEN invalid void attempts target a credit-payment row and then a void row
-    THEN business errors are raised and transaction count only changes for the valid void
+    WHEN invalid void attempts target a void row
+    THEN business errors are raised and transaction count only changes for valid voids
     """
     _add_product(initialized_context, "WF-P013", price=900)
     _add_salesman(initialized_context, "WF-S013")
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="WF-P013",
+            salesman_id="WF-S013",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
 
     credit_sale = bll.record_sale(
         initialized_context,
@@ -467,13 +485,12 @@ def test_invalid_void_chains_raise_without_creating_partial_rows(
         ),
     )
 
-    before_invalid_voids = len(bll.list_transactions(initialized_context))
+    payment_void = bll.record_void(
+        initialized_context,
+        bll.VoidCommand(linked_transaction_id=payment.transaction_id),
+    )
 
-    with pytest.raises(exceptions.BusinessRuleViolation):
-        bll.record_void(
-            initialized_context,
-            bll.VoidCommand(linked_transaction_id=payment.transaction_id),
-        )
+    before_invalid_voids = len(bll.list_transactions(initialized_context))
 
     valid_void = bll.record_void(
         initialized_context,

--- a/backend/tests/integration/test_reporting_integration.py
+++ b/backend/tests/integration/test_reporting_integration.py
@@ -95,6 +95,15 @@ def test_profit_summary_matches_revenue_plus_cost_over_transaction_log(
     _add_product(initialized_context, "RP-P002")
     _add_salesman(initialized_context, "RP-S002")
 
+    bll.record_restock(
+        initialized_context,
+        bll.RestockCommand(
+            product_id="RP-P002",
+            salesman_id="RP-S002",
+            quantity=2,
+            total_cost=750,
+        ),
+    )
     bll.record_sale(
         initialized_context,
         bll.SaleCommand(
@@ -103,15 +112,6 @@ def test_profit_summary_matches_revenue_plus_cost_over_transaction_log(
             quantity=1,
             total_revenue=3000,
             payment_type=constants.PaymentType.CASH,
-        ),
-    )
-    bll.record_restock(
-        initialized_context,
-        bll.RestockCommand(
-            product_id="RP-P002",
-            salesman_id="RP-S002",
-            quantity=2,
-            total_cost=750,
         ),
     )
 
@@ -131,6 +131,15 @@ def test_outstanding_debts_report_tracks_partial_and_full_credit_payments(
     """
     _add_product(initialized_context, "RP-P003", price=1000)
     _add_salesman(initialized_context, "RP-S003")
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="RP-P003",
+            salesman_id="RP-S003",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
 
     partially_paid_sale = bll.record_sale(
         initialized_context,
@@ -190,6 +199,15 @@ def test_outstanding_debts_excludes_voided_credit_sales_in_end_to_end_flow(
     """
     _add_product(initialized_context, "RP-P004", price=1200)
     _add_salesman(initialized_context, "RP-S004")
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="RP-P004",
+            salesman_id="RP-S004",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
 
     credit_sale = bll.record_sale(
         initialized_context,
@@ -304,6 +322,24 @@ def test_outstanding_debts_ignores_overpaid_sales_and_aggregates_remaining_balan
     _add_product(initialized_context, "RP-P007", price=1000)
     _add_product(initialized_context, "RP-P008", price=600)
     _add_salesman(initialized_context, "RP-S007")
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="RP-P007",
+            salesman_id="RP-S007",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
+    bll.record_open_stock(
+        initialized_context,
+        bll.OpenStockCommand(
+            product_id="RP-P008",
+            salesman_id="RP-S007",
+            quantity=10,
+            total_revenue=0,
+        ),
+    )
 
     overpaid_sale = bll.record_sale(
         initialized_context,

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -179,23 +179,45 @@ corrections.
 
 ### Workflows
 
+#### Stock Availability Enforcement
+
+Sales (`record_sale`, `record_bulk_sale`) and write-offs (`record_write_off`)
+strictly enforce stock availability. The business logic layer calculates dynamic
+inventory balances (`calculate_inventory`) from the transaction log and rejects
+any sale or write-off request where requested quantity exceeds available stock.
+Bulk sales validate aggregate cart item quantities per product atomically.
+
 #### Discounts
 
 Handled by allowing any `TotalRevenue` during a sale, even if it will differ
 from the product's sell price.
 
-#### Sell on Credit
+#### Sell on Credit & Flexible Credit Payments
 
-Logged as a `SALE` with `PaymentType="OnCredit"` and zero revenue, paired with a
-subsequent `CREDIT_PAYMENT` that references the original transaction via
-`LinkedTransactionID`. Credit payment entries capture the actual settlement
-method (`PaymentType` on the command) and the value paid.
+Logged as a `SALE` with `PaymentType="OnCredit"` and zero revenue, paired with
+subsequent `CREDIT_PAYMENT` transactions referencing the original sale via
+`LinkedTransactionID`.
 
-#### Error Correction
+- **Multiple Partial Payments:** Customers can make multiple partial payments
+  over time.
+- **Overpayments & Interest:** Payment amounts are not capped by the remaining
+  debt balance, allowing salesmen to record interest, late fees, or extra
+  payments.
+- **Traceability & Reports:** Outstanding debt reports sum all non-voided
+  `CREDIT_PAYMENT` entries for a sale, excluding fully settled or overpaid debts
+  from outstanding balances.
+
+#### Error Correction & Voiding Credit Payments
 
 Uses the "Reversal and Re-entry" method. A `VOID` transaction reverses the
-mistake, followed by a new entry with the correct data. The correct data is
-optional if only want to delete the mistake.
+mistake by flipping quantity/revenue/cost deltas, followed by a new entry if
+correcting data.
+
+- **Voiding Credit Payments:** `CREDIT_PAYMENT` entries can be voided just like
+  sales or restocks. Voiding a credit payment automatically restores the unpaid
+  debt balance on the linked credit sale.
+- **Immutability of Voids:** Only `VOID` transactions themselves cannot be
+  voided to prevent infinite reversal loops.
 
 #### Bulk Sales (Atomic Multi-Item Checkouts)
 


### PR DESCRIPTION
Fixes #92 

Add not only stock enforcement but also allow multiple credit payments to the same credit sale (partial payments) and allow credit payment voiding.